### PR TITLE
fix(agents): correct frontmatter and cross-references in spec pipeline

### DIFF
--- a/.claude/agents/spec.00.overview.md
+++ b/.claude/agents/spec.00.overview.md
@@ -2,7 +2,12 @@
 name: spec.00.overview
 description: "Spec Pipeline router — inspects the spec directory for a feature, determines current pipeline state, and recommends the next phase to run. Use when the user asks 'what's next' or wants pipeline status."
 model: sonnet
-tools: Read, Glob, Grep, Bash
+allowedTools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - TodoWrite
 ---
 
 # Spec Pipeline: Router

--- a/.claude/agents/spec.01.questions.md
+++ b/.claude/agents/spec.01.questions.md
@@ -2,7 +2,17 @@
 name: spec.01.questions
 description: "Spec Phase 1 — Generate targeted research questions from an Issue or Feature request. Accepts feature description as input, derives slug, writes questions file, and creates GitHub tracking issue."
 model: opus
-tools: Read, Write, Glob, Grep, Bash, mcp__github__get_issue, mcp__github__search_issues, mcp__github__create_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__search_issues
+  - mcp__github__create_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Phase 1: Questions

--- a/.claude/agents/spec.02.research.md
+++ b/.claude/agents/spec.02.research.md
@@ -2,7 +2,16 @@
 name: spec.02.research
 description: "Spec Phase 2 — Objective, fact-based codebase research driven by Phase 1 questions. Spawns parallel Explore agents, synthesizes findings with file:line references, and writes the research document."
 model: opus
-tools: Read, Write, Glob, Grep, Bash, Agent, mcp__github__get_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Phase 2: Research

--- a/.claude/agents/spec.03.design.md
+++ b/.claude/agents/spec.03.design.md
@@ -2,7 +2,16 @@
 name: spec.03.design
 description: "Spec Phase 3 — Interactive design discussion to align on what to build and how. Reads research, surfaces trade-offs via AskUserQuestion, and writes the design document after explicit engineer approval."
 model: opus
-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, mcp__github__get_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Phase 3: Design

--- a/.claude/agents/spec.04.outline.md
+++ b/.claude/agents/spec.04.outline.md
@@ -2,7 +2,16 @@
 name: spec.04.outline
 description: "Spec Phase 4 — Structure implementation into vertical slices with test checkpoints. Reads research + design, drafts outline, gets engineer approval via AskUserQuestion, writes outline document."
 model: sonnet
-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, mcp__github__get_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Phase 4: Outline

--- a/.claude/agents/spec.05.plan.md
+++ b/.claude/agents/spec.05.plan.md
@@ -2,7 +2,17 @@
 name: spec.05.plan
 description: "Spec Phase 5 — Expand outline into detailed implementation plan with specific file changes, function signatures, test commands, and per-phase GitHub issues."
 model: opus
-tools: Read, Write, Glob, Grep, Bash, mcp__github__get_issue, mcp__github__update_issue, mcp__github__create_issue, mcp__github__add_issue_comment
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
+  - mcp__github__create_issue
+  - mcp__github__add_issue_comment
 ---
 
 # Spec Phase 5: Plan

--- a/.claude/agents/spec.06.worktree.md
+++ b/.claude/agents/spec.06.worktree.md
@@ -2,7 +2,16 @@
 name: spec.06.worktree
 description: "Spec Phase 6 — Analyze plan for parallelism, create isolated git worktrees for independent phases. Gets engineer approval before modifying git state."
 model: sonnet
-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, mcp__github__get_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Phase 6: Worktree

--- a/.claude/agents/spec.07.implement.md
+++ b/.claude/agents/spec.07.implement.md
@@ -2,7 +2,21 @@
 name: spec.07.implement
 description: "Spec Phase 7 — Autonomous implementation orchestrator. Spawns spec.07.worker sub-agents per worktree, enforces test checkpoints with auto-recovery, auto-merges batches, and only escalates genuine blockers."
 model: opus
-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, WebSearch, WebFetch, AskUserQuestion, mcp__github__get_issue, mcp__github__update_issue, mcp__github__add_issue_comment
+allowedTools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - WebSearch
+  - WebFetch
+  - AskUserQuestion
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
+  - mcp__github__add_issue_comment
 ---
 
 # Spec Phase 7: Implement

--- a/.claude/agents/spec.07.recovery.md
+++ b/.claude/agents/spec.07.recovery.md
@@ -2,7 +2,12 @@
 name: spec.07.recovery
 description: "Spec Phase 7 recovery agent — diagnoses checkpoint failures by reading error output, plan context, and affected files. Returns a structured fix recommendation for the orchestrator to apply."
 model: opus
-tools: Read, Glob, Grep, Bash, WebSearch
+allowedTools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - WebSearch
 ---
 
 # Spec Phase 7: Recovery Agent

--- a/.claude/agents/spec.07.worker.md
+++ b/.claude/agents/spec.07.worker.md
@@ -2,7 +2,15 @@
 name: spec.07.worker
 description: "Spec Phase 7 worker — Implementation sub-agent spawned by spec.07.implement. Executes assigned phases in a worktree, runs test checkpoints, commits changes. Does not interact with the user."
 model: sonnet
-tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
+allowedTools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - WebSearch
+  - WebFetch
 ---
 
 # Spec Phase 7: Implementation Worker

--- a/.claude/agents/spec.08.hotfix.md
+++ b/.claude/agents/spec.08.hotfix.md
@@ -2,7 +2,19 @@
 name: spec.08.hotfix
 description: "Spec Phase 8 hotfix — applies changes requested in PR review comments. Reads review feedback, maps to plan/design, implements fixes, and updates the PR."
 model: sonnet
-tools: Read, Write, Edit, Glob, Grep, Bash, mcp__github__get_pull_request, mcp__github__get_pull_request_comments, mcp__github__get_pull_request_reviews, mcp__github__get_pull_request_files, mcp__github__add_issue_comment, mcp__github__update_pull_request_branch
+allowedTools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - mcp__github__get_pull_request
+  - mcp__github__get_pull_request_comments
+  - mcp__github__get_pull_request_reviews
+  - mcp__github__get_pull_request_files
+  - mcp__github__add_issue_comment
+  - mcp__github__update_pull_request_branch
 ---
 
 # Spec Phase 8: Hotfix

--- a/.claude/agents/spec.08.pull-request.md
+++ b/.claude/agents/spec.08.pull-request.md
@@ -2,7 +2,21 @@
 name: spec.08.pull-request
 description: "Spec Phase 8 — Create a pull request with thorough description from the full pipeline history. Reads design, plan, and implementation log to generate PR context. Creates or updates the PR via gh."
 model: sonnet
-tools: Read, Write, Edit, Glob, Grep, Bash, mcp__github__get_issue, mcp__github__update_issue, mcp__github__add_issue_comment, mcp__github__create_pull_request, mcp__github__get_pull_request, mcp__github__get_pull_request_files, mcp__github__create_pull_request_review
+allowedTools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
+  - mcp__github__add_issue_comment
+  - mcp__github__create_pull_request
+  - mcp__github__get_pull_request
+  - mcp__github__get_pull_request_files
+  - mcp__github__create_pull_request_review
 ---
 
 # Spec Phase 8: Pull Request

--- a/.claude/agents/spec.09.cleanup.md
+++ b/.claude/agents/spec.09.cleanup.md
@@ -2,7 +2,17 @@
 name: spec.09.cleanup
 description: "Spec Phase 9 — Archive spec directory after PR is merged. Verifies merge status, closes GitHub issues, deletes feature branches, moves spec files to dated archive."
 model: haiku
-tools: Read, Write, Glob, Grep, Bash, mcp__github__get_pull_request, mcp__github__list_pull_requests, mcp__github__get_issue, mcp__github__update_issue, mcp__github__add_issue_comment
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - mcp__github__get_pull_request
+  - mcp__github__list_pull_requests
+  - mcp__github__get_issue
+  - mcp__github__update_issue
+  - mcp__github__add_issue_comment
 ---
 
 # Spec Phase 9: Cleanup

--- a/.claude/agents/spec.run.md
+++ b/.claude/agents/spec.run.md
@@ -2,7 +2,17 @@
 name: spec.run
 description: "Spec Pipeline orchestrator — drives the full pipeline from feature description to merged PR. Automatically chains phases, passes file paths, and pauses only at human approval gates (design, outline, worktree)."
 model: opus
-tools: Read, Write, Glob, Grep, Bash, Agent, AskUserQuestion, mcp__github__get_issue, mcp__github__update_issue
+allowedTools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+  - AskUserQuestion
+  - TodoWrite
+  - mcp__github__get_issue
+  - mcp__github__update_issue
 ---
 
 # Spec Pipeline: Orchestrator

--- a/.claude/agents/spec.validate.md
+++ b/.claude/agents/spec.validate.md
@@ -2,7 +2,11 @@
 name: spec.validate
 description: "Spec pre-flight validator — checks phase prerequisites, artifact integrity, tool availability, and meta.md consistency before a phase runs. Returns pass/fail with specific remediation."
 model: haiku
-tools: Read, Glob, Grep, Bash
+allowedTools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
 ---
 
 # Spec Validator: Pre-flight Check

--- a/.claude/commands/spec.00.overview.md
+++ b/.claude/commands/spec.00.overview.md
@@ -1,6 +1,6 @@
 ---
 name: spec.00.overview
-description: "Spec Pipeline — Overview of all 8 phases and how to invoke them in sequence. Use when the user wants to understand the spec pipeline, see the phase map, or get guidance on which phase to run next."
+description: "Spec Pipeline — Overview of all 9 phases and how to invoke them in sequence. Use when the user wants to understand the spec pipeline, see the phase map, or get guidance on which phase to run next."
 argument-hint: Optional feature description to get phase-specific guidance.
 allowed-tools: Read, Glob
 ---

--- a/.claude/commands/spec.04.outline.md
+++ b/.claude/commands/spec.04.outline.md
@@ -1,7 +1,7 @@
 ---
 name: spec.04.outline
 description: "Spec Phase 4 — High-level structured outline: phases, ordering, testing checkpoints, key signatures. Use after Phase 3 design is approved: provide the research and design file paths and this will structure implementation into vertical slices with test checkpoints."
-argument-hint: Path to design file from Phase 3 (e.g. `.claude/specs/{feature-slug}/03-design-{NN}.md`)
+argument-hint: Paths to research and design files from Phases 2-3 (e.g. `.claude/specs/{feature-slug}/02-research-{NN}.md .claude/specs/{feature-slug}/03-design-{NN}.md`)
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion, TodoWrite, mcp__github__get_issue, mcp__github__update_issue
 ---
 

--- a/.claude/commands/spec.07.implement.md
+++ b/.claude/commands/spec.07.implement.md
@@ -36,7 +36,7 @@ Before proceeding, verify both files exist by reading them. If either is missing
 4. **Spawn sub-agents in parallel** for all worktrees in the current batch. Launch all agents in a single message (parallel calls). Use `mode: "bypassPermissions"` so sub-agents write files without prompting. Use this invocation template for each:
 
    ```yaml
-   subagent_type: "general-purpose"
+   subagent_type: "spec.07.worker"
    mode: "bypassPermissions"
    prompt: |
      You are an implementation agent for the {feature-name} feature.


### PR DESCRIPTION
## Summary
- Rename `tools` to `allowedTools` (YAML array format) in all 15 custom agent files — the old field name was not recognized by Claude Code
- Add missing `TodoWrite` tool to agent files where the matching command already had it
- Fix `commands/spec.07.implement.md` to spawn `spec.07.worker` subagent instead of `general-purpose`
- Fix `spec.00.overview` description from "8 phases" to "9 phases"
- Fix `spec.04.outline` argument-hint to mention both required input files (research + design)

## Test plan
- [ ] Verify agents load correctly in a new Claude Code session (`/spec.00.overview` shows updated description)
- [ ] Verify `allowedTools` restricts tool access as expected when spawning agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)