### PR TITLE
docs: enhance trading desk TOCs with descriptions and key concepts

### DIFF
--- a/docs/trading-desk/01-market-data-systems/README.md
+++ b/docs/trading-desk/01-market-data-systems/README.md
@@ -4,11 +4,26 @@ Market data systems form the nervous system of any professional trading desk. Re
 
 ## Contents
 
-1. [Overview and Real-Time Market Data Feeds](01_Overview-And-Real-Time-Market-Data-Feeds.md)
-2. [Market Data Sources and Exchanges](02_Market-Data-Sources-And-Exchanges.md)
-3. [Data Normalization and Market Data Protocols](03_Data-Normalization-And-Market-Data-Protocols.md)
-4. [Tick Data Storage and Conflation](04_Tick-Data-Storage-And-Conflation.md)
-5. [Reference Data and Static Data](05_Reference-Data-And-Static-Data.md)
-6. [Historical Market Data and Entitlements](06_Historical-Market-Data-And-Entitlements.md)
-7. [Market Data Infrastructure](07_Market-Data-Infrastructure.md)
-8. [Alternative Data and Appendices](08_Alternative-Data-And-Appendices.md)
+1. [Overview and Real-Time Market Data Feeds](01_Overview-And-Real-Time-Market-Data-Feeds.md) — Core responsibilities of market data systems and Level 1/2/3 feed structures including top-of-book, depth-of-book, and order-level data
+   - `BBO`, `NBBO`, `MarketByPrice`, `MarketByOrder`, `QuoteConditionCode`, `ImpliedBook`
+
+2. [Market Data Sources and Exchanges](02_Market-Data-Sources-And-Exchanges.md) — Global exchange landscape (equities, derivatives), consolidated vs. direct feeds, and third-party vendor integrations
+   - `SIP`, `CTA`, `UTP`, `DirectFeed`, `ConsolidatedTape`, `ExchangeFeedSubscription`
+
+3. [Data Normalization and Market Data Protocols](03_Data-Normalization-And-Market-Data-Protocols.md) — Symbology mapping (ISIN, CUSIP, SEDOL, FIGI), price/quantity normalization, and binary protocols (ITCH, PITCH, SBE, FAST)
+   - `SymbologyMap`, `PriceScaling`, `TimestampNormalize()`, `ITCH`, `OUCH`, `PITCH`, `SBE`, `FAST`, `FIXMessage`
+
+4. [Tick Data Storage and Conflation](04_Tick-Data-Storage-And-Conflation.md) — Tick-level storage architectures, time-series databases, bar aggregation (OHLCV), VWAP calculation, and conflation strategies
+   - `TickStore`, `OHLCV`, `VWAP`, `Conflation`, `BarAggregation`, `PartitionByDate`, `RDB`, `Tickerplant`
+
+5. [Reference Data and Static Data](05_Reference-Data-And-Static-Data.md) — Instrument master (security master), corporate actions handling, holiday calendars, trading hours, tick size tables, and lot sizes
+   - `InstrumentMaster`, `CorporateAction`, `HolidayCalendar`, `TradingHours`, `TickSizeTable`, `LotSize`
+
+6. [Historical Market Data and Entitlements](06_Historical-Market-Data-And-Entitlements.md) — EOD data, intraday history, replay capabilities, backtesting data requirements, and exchange data licensing and entitlement management
+   - `EODData`, `ReplayEngine`, `BacktestUniverse`, `EntitlementManager`, `DisplayUsage`, `NonDisplayUsage`, `VendorOfRecordReport`
+
+7. [Market Data Infrastructure](07_Market-Data-Infrastructure.md) — Feed handler architecture (software, FPGA), ticker plants, pub/sub distribution, network topology, and latency measurement
+   - `FeedHandler`, `TickerPlant`, `PubSub`, `TopicHierarchy`, `LatencyMeasurement`, `KernelBypass`, `HardwareTimestamp`
+
+8. [Alternative Data and Appendices](08_Alternative-Data-And-Appendices.md) — News feeds, social sentiment, economic indicators, weather data, satellite imagery, and key metrics/benchmarks/glossary
+   - `MachineReadableNews`, `SentimentScore`, `EconomicIndicator`, `AlternativeDataPipeline`, `PointInTimeIntegrity`

--- a/docs/trading-desk/02-order-management-system/README.md
+++ b/docs/trading-desk/02-order-management-system/README.md
@@ -4,14 +4,35 @@ Reference documentation covering the design, behavior, and integration concerns 
 
 ## Contents
 
-1. [Order Types](01_Order-Types.md)
-2. [Order Lifecycle and State Machine](02_Order-Lifecycle-And-State-Machine.md)
-3. [Order Routing and Smart Order Routing](03_Order-Routing-And-Smart-Order-Routing.md)
-4. [Order Validation and Pre-Trade Checks](04_Order-Validation-And-Pre-Trade-Checks.md)
-5. [Amendments, Cancellations, and Parent/Child Orders](05_Amendments-Cancellations-And-Parent-Child-Orders.md)
-6. [Order Book Management](06_Order-Book-Management.md)
-7. [Multi-Asset Order Management](07_Multi-Asset-Order-Management.md)
-8. [FIX Protocol Integration](08_FIX-Protocol-Integration.md)
-9. [Drop Copy, Audit Trails, and Care vs DMA Orders](09_Drop-Copy-Audit-Trails-And-Care-Vs-DMA-Orders.md)
-10. [Allocation and Post-Trade Order Splitting](10_Allocation-And-Post-Trade-Order-Splitting.md)
-11. [Appendices](11_Appendices.md)
+1. [Order Types](01_Order-Types.md) — Market, limit, stop, trailing stop, iceberg, pegged, and auction order types with time-in-force variants and FIX tag mappings
+   - `MarketOrder`, `LimitOrder`, `StopOrder`, `TrailingStop`, `IcebergOrder`, `PeggedOrder`, `TimeInForce`, `MaxFloor`
+
+2. [Order Lifecycle and State Machine](02_Order-Lifecycle-And-State-Machine.md) — FIX-standard order states (PendingNew through Expired), valid transitions, race conditions, internal OMS states, and order versioning
+   - `OrdStatus`, `OrderStateMachine`, `FillBeforeCancel`, `UnsolicitedCancel`, `OrderVersion`, `StagedOrder`, `AlgoWorking`
+
+3. [Order Routing and Smart Order Routing](03_Order-Routing-And-Smart-Order-Routing.md) — DMA routing, SOR decision logic with venue scoring, broker algo routing (VWAP, TWAP, IS, POV), and venue connectivity management
+   - `SmartOrderRouter`, `DMARoute()`, `VenueScore`, `BrokerAlgoRoute()`, `FIXSession`, `ExDestination`
+
+4. [Order Validation and Pre-Trade Checks](04_Order-Validation-And-Pre-Trade-Checks.md) — Sequential validation pipeline: schema validation, fat-finger checks, restricted lists, position limits, credit/buying power, short sale rules, and SEC 15c3-5 compliance
+   - `ValidationPipeline`, `FatFingerCheck`, `PositionLimitCheck`, `CreditCheck`, `RestrictedListCheck`, `ShortSaleLocate`, `MarketAccessControl`
+
+5. [Amendments, Cancellations, and Parent/Child Orders](05_Amendments-Cancellations-And-Parent-Child-Orders.md) — Cancel and cancel/replace request handling, mass cancel, cancel-on-disconnect, parent/child algo decomposition, bracket orders, and OCO logic
+   - `OrderCancelRequest`, `CancelReplaceRequest`, `MassCancel`, `CancelOnDisconnect`, `ParentChildOrder`, `BracketOrder`, `OCO`, `ContingentOrder`
+
+6. [Order Book Management](06_Order-Book-Management.md) — Blotter views (working orders, fills, audit trail), real-time position tracking with P&L, and multi-venue order aggregation
+   - `WorkingOrderBlotter`, `ExecutionBlotter`, `PositionView`, `UnrealizedPnL`, `RealizedPnL`, `OrderBookAggregation`
+
+7. [Multi-Asset Order Management](07_Multi-Asset-Order-Management.md) — Asset-class-specific order handling for equities, fixed income (RFQ), FX (streaming prices), listed derivatives, and commodities with unified API architecture
+   - `EquityOrderHandler`, `FixedIncomeRFQ`, `FXStreamingPrice`, `DerivativesHandler`, `UnifiedOrderAPI`, `PriceFormatNormalize`
+
+8. [FIX Protocol Integration](08_FIX-Protocol-Integration.md) — FIX session management (logon, heartbeat, sequence numbers, gap-fill recovery), core order messages (NewOrderSingle, ExecutionReport, CancelRequest), and party identification
+   - `FIXSession`, `NewOrderSingle`, `ExecutionReport`, `OrderCancelRequest`, `SequenceNumberManager`, `ResendRequest`, `GapFill`
+
+9. [Drop Copy, Audit Trails, and Care vs DMA Orders](09_Drop-Copy-Audit-Trails-And-Care-Vs-DMA-Orders.md) — Drop copy architecture for independent risk/compliance monitoring, regulatory audit trails (CAT, MiFID II), and care order vs. DMA order workflow distinctions
+   - `DropCopySession`, `AuditTrail`, `CATReporting`, `CareOrder`, `DMAOrder`, `HandlInst`, `NotHeld`
+
+10. [Allocation and Post-Trade Order Splitting](10_Allocation-And-Post-Trade-Order-Splitting.md) — Block order allocation methods (pro-rata, rotational, minimum dispersion), average price processing, FIX allocation messages, step-out/give-up, and post-trade booking workflow
+    - `BlockAllocation`, `ProRataAlloc`, `AveragePriceCalc`, `AllocationInstruction`, `AllocationReport`, `StepOut`, `GiveUp`, `TradeBooking`
+
+11. [Appendices](11_Appendices.md) — FIX tag reference tables, OrdRejReason values, and ExecRestatementReason codes
+    - `FIXTagReference`, `OrdRejReason`, `ExecRestatementReason`, `CxlRejReason`

--- a/docs/trading-desk/03-execution-and-algorithms/README.md
+++ b/docs/trading-desk/03-execution-and-algorithms/README.md
@@ -4,16 +4,41 @@ Covers execution algorithms, smart order routing, direct market access, dark poo
 
 ## Contents
 
-1. [Execution Algorithms (Part 1)](01_Execution-Algorithms-Part-1.md)
-2. [Execution Algorithms (Part 2)](02_Execution-Algorithms-Part-2.md)
-3. [Algorithm Parameters and Customization](03_Algorithm-Parameters-And-Customization.md)
-4. [Smart Order Routing](04_Smart-Order-Routing.md)
-5. [Direct Market Access](05_Direct-Market-Access.md)
-6. [Dark Pools and Alternative Trading Systems](06_Dark-Pools-And-Alternative-Trading-Systems.md)
-7. [Execution Quality Measurement](07_Execution-Quality-Measurement.md)
-8. [Execution Venue Analysis](08_Execution-Venue-Analysis.md)
-9. [High-Frequency Trading Considerations](09_High-Frequency-Trading-Considerations.md)
-10. [Market Microstructure](10_Market-Microstructure.md)
-11. [Best Execution Obligations](11_Best-Execution-Obligations.md)
-12. [Basket and Portfolio Trading](12_Basket-And-Portfolio-Trading.md)
-13. [Appendices](13_Appendices.md)
+1. [Execution Algorithms (Part 1)](01_Execution-Algorithms-Part-1.md) — VWAP, TWAP, POV/participation rate, and implementation shortfall (arrival price) algorithms with volume profile construction and cost model optimization
+   - `VWAPAlgo`, `TWAPAlgo`, `POVAlgo`, `ImplementationShortfall`, `VolumeProfile`, `SliceScheduler`, `AdaptiveVWAP`
+
+2. [Execution Algorithms (Part 2)](02_Execution-Algorithms-Part-2.md) — MOC/close algorithms, iceberg/reserve management, sniper/liquidity-seeking, dark pool algorithms, and pairs trading execution
+   - `CloseAlgo`, `IcebergAlgo`, `SniperAlgo`, `DarkPoolAlgo`, `PairsTradingAlgo`, `LiquidityDetection`, `DarkPoolPing`
+
+3. [Algorithm Parameters and Customization](03_Algorithm-Parameters-And-Customization.md) — Universal parameters, urgency levels, price limit/peg configuration, venue controls, sizing controls, and FIXatdl strategy parameter encoding
+   - `Urgency`, `LimitPrice`, `WouldPrice`, `PegType`, `DarkPoolInclusion`, `SliceSize`, `FIXatdl`, `StrategyParameterGrp`
+
+4. [Smart Order Routing](04_Smart-Order-Routing.md) — Venue landscape analysis, fill probability models, maker-taker/inverted fee optimization, routing table configuration, order type compatibility matrix, and SOR decision flow
+   - `SmartOrderRouter`, `RoutingTable`, `FeeOptimizer`, `FillProbabilityModel`, `VenueCapabilityMatrix`, `SweepMode`
+
+5. [Direct Market Access](05_Direct-Market-Access.md) — Sponsored access, co-location, proximity hosting, DMA risk controls (SEC 15c3-5), and latency budget breakdown for co-located order flow
+   - `SponsoredAccess`, `CoLocation`, `DMAGateway`, `RiskGateway`, `KillSwitch`, `PriceCollar`, `RateLimit`
+
+6. [Dark Pools and Alternative Trading Systems](06_Dark-Pools-And-Alternative-Trading-Systems.md) — Dark pool types (exchange, broker, independent), matching mechanisms (midpoint, periodic auction, conditional), IOIs, and Reg ATS/MiFID II dark pool regulation
+   - `DarkPool`, `MidpointMatch`, `PeriodicAuction`, `ConditionalOrder`, `IOI`, `RegATS`, `FormATS_N`, `DoubleVolumeCap`
+
+7. [Execution Quality Measurement](07_Execution-Quality-Measurement.md) — Transaction cost analysis (TCA) with explicit/implicit cost decomposition, benchmarks (arrival, VWAP, close), implementation shortfall framework, and pre/real-time/post-trade TCA reporting
+   - `TCA`, `ArrivalSlippage`, `VWAPSlippage`, `SpreadCapture`, `ImplementationShortfallDecomp`, `MarketImpact`, `TimingCost`, `OpportunityCost`
+
+8. [Execution Venue Analysis](08_Execution-Venue-Analysis.md) — Fill rate analysis, adverse selection measurement, information leakage detection, venue toxicity metrics (VPIN), and composite venue scoring models
+   - `FillRateAnalysis`, `AdverseSelection`, `InformationLeakage`, `VPIN`, `VenueScore`, `PhantomLiquidity`, `SpreadDecomposition`
+
+9. [High-Frequency Trading Considerations](09_High-Frequency-Trading-Considerations.md) — Tick-to-trade latency breakdown, co-location facilities, FPGA/ASIC hardware acceleration, kernel bypass (OpenOnload, DPDK), and time synchronization (PTP)
+   - `TickToTrade`, `FPGA`, `KernelBypass`, `OpenOnload`, `DPDK`, `PTP`, `HardwareTimestamp`, `NICSolarflare`
+
+10. [Market Microstructure](10_Market-Microstructure.md) — Bid-ask spread dynamics, order book event processing (add/modify/cancel/execute), market maker behavior (DMM, electronic), price discovery, and queue priority rules (FIFO, pro-rata)
+    - `BidAskSpread`, `OrderBookEvent`, `DesignatedMarketMaker`, `PriceDiscovery`, `QueuePriority`, `BookImbalance`, `DepthAnalysis`
+
+11. [Best Execution Obligations](11_Best-Execution-Obligations.md) — US Reg NMS (Rules 611, 610, 612), FINRA 5310, MiFID II best execution (Article 27), RTS 27/28 reporting, and best execution policy implementation
+    - `RegNMS`, `OrderProtectionRule`, `SubPennyRule`, `MiFIDBestExecution`, `RTS28Report`, `Rule606`, `BestExecutionPolicy`
+
+12. [Basket and Portfolio Trading](12_Basket-And-Portfolio-Trading.md) — List/program trading, index rebalancing execution, transition management, basket risk management (net exposure, sector/factor neutrality), and cash management
+    - `BasketOrder`, `ProgramTrade`, `IndexRebalance`, `TransitionManager`, `NetExposureMonitor`, `CrossTrade`, `TrackingError`
+
+13. [Appendices](13_Appendices.md) — FIX protocol tags for algorithmic trading, US equity venue MIC code reference, and key academic references (Almgren-Chriss, Kyle, Perold)
+    - `StrategyParameterName`, `StrategyParameterValue`, `MICCode`, `AlmgrenChriss`, `VPIN`

--- a/docs/trading-desk/04-position-management/README.md
+++ b/docs/trading-desk/04-position-management/README.md
@@ -4,10 +4,23 @@ Comprehensive reference for position management as implemented in professional t
 
 ## Contents
 
-1. [Real-Time Position Tracking](01_Real-Time-Position-Tracking.md)
-2. [Multi-Currency Positions](02_Multi-Currency-Positions.md)
-3. [Position Reconciliation](03_Position-Reconciliation.md)
-4. [Corporate Actions Impact on Positions](04_Corporate-Actions-Impact-On-Positions.md)
-5. [Average Cost and Tax Lot Tracking](05_Average-Cost-And-Tax-Lot-Tracking.md)
-6. [Position Limits and Monitoring](06_Position-Limits-And-Monitoring.md)
-7. [SOD Positions and Data Model](07_SOD-Positions-And-Data-Model.md)
+1. [Real-Time Position Tracking](01_Real-Time-Position-Tracking.md) — Core position records, intraday/realized/unrealized P&L, mark-to-market, P&L attribution, and hierarchical position views
+   - `PositionKey`, `IntradayPnL`, `RealizedPnL`, `UnrealizedPnL`, `TotalPnL`, `Notional`, `AverageCost`, `MarketPrice`, `ContractMultiplier`
+
+2. [Multi-Currency Positions](02_Multi-Currency-Positions.md) — Base currency conversion, FX exposure calculation, cross-currency P&L decomposition, multi-currency cash balances, buying power, and margin requirements
+   - `FxExposure()`, `PositionValue_Base`, `LocalPnL`, `FxPnL`, `BuyingPower`, `MarginExcess`, `SPANMargin`
+
+3. [Position Reconciliation](03_Position-Reconciliation.md) — Trade date vs. settlement date positions, street-side vs. house-side reconciliation, break categories, matching workflows, and tolerances
+   - `ReconciliationWorkflow`, `BreakDetection`, `NormalizeInstrumentId()`, `MatchByPositionKey()`, `BreakCategory`, `ReconciliationTolerance`
+
+4. [Corporate Actions Impact on Positions](04_Corporate-Actions-Impact-On-Positions.md) — Stock splits, dividends, mergers, spin-offs, tender offers, rights issues, and derivative adjustments from corporate events
+   - `SplitRatio`, `CashDividend`, `StockDividend`, `MergerPrice`, `ExchangeRatio`, `SpinOffAllocation`, `TenderOffer`, `RightsIssue`
+
+5. [Average Cost and Tax Lot Tracking](05_Average-Cost-And-Tax-Lot-Tracking.md) — Tax lot management, FIFO/LIFO/specific lot/average cost methods, wash sale rules, and multi-currency tax lots
+   - `TaxLot`, `FIFO`, `LIFO`, `SpecificLotIdentification`, `AverageCost`, `WashSaleAdjustment`, `CostBasis`, `FxRateAtPurchase`
+
+6. [Position Limits and Monitoring](06_Position-Limits-And-Monitoring.md) — Multi-layer limit types, limit metrics, monitoring architecture, utilization thresholds, hard vs. soft limits, regulatory position limits, and concentration risk
+   - `PositionLimit`, `LimitUtilization`, `PreTradeLimitCheck`, `HHI`, `ConcentrationLimit`, `RegulatoryLimit`, `StopLoss`
+
+7. [SOD Positions and Data Model](07_SOD-Positions-And-Data-Model.md) — Start-of-day position build process, SOD attributes, position break detection and aging, and the core data model for positions, tax lots, and limits
+   - `SODPosition`, `SODQuantity`, `SODAverageCost`, `BreakDetection`, `BreakEscalation`, `Position`, `TaxLot`, `CorporateActionAdjustment`, `PositionLimit`

--- a/docs/trading-desk/05-risk-management/README.md
+++ b/docs/trading-desk/05-risk-management/README.md
@@ -4,15 +4,38 @@ Comprehensive reference for risk management as implemented in professional tradi
 
 ## Contents
 
-1. [Market Risk](01_Market-Risk.md)
-2. [Credit Risk](02_Credit-Risk.md)
-3. [Liquidity and Operational Risk](03_Liquidity-And-Operational-Risk.md)
-4. [Pre-Trade Risk Controls](04_Pre-Trade-Risk-Controls.md)
-5. [Real-Time Risk Calculations: Options Greeks](05_Real-Time-Risk-Calculations-Options-Greeks.md)
-6. [Real-Time Risk Calculations: Fixed Income and Architecture](06_Real-Time-Risk-Calculations-Fixed-Income-And-Architecture.md)
-7. [Risk Limits and Breaches](07_Risk-Limits-And-Breaches.md)
-8. [Stress Testing and Scenario Analysis](08_Stress-Testing-And-Scenario-Analysis.md)
-9. [Regulatory Risk Requirements](09_Regulatory-Risk-Requirements.md)
-10. [Risk Attribution and Factor Models](10_Risk-Attribution-Factor-Models.md)
-11. [Risk Attribution: Marginal and Component](11_Risk-Attribution-Marginal-And-Component.md)
-12. [Appendices](12_Appendices.md)
+1. [Market Risk](01_Market-Risk.md) — Value at Risk (historical, parametric, Monte Carlo), Expected Shortfall, stress testing fundamentals, and confidence level / time horizon conventions
+   - `HistoricalVaR()`, `ParametricVaR()`, `MonteCarloVaR()`, `ExpectedShortfall()`, `CovarianceMatrix`, `CholeskyDecomposition`, `sigma_portfolio`
+
+2. [Credit Risk](02_Credit-Risk.md) — Counterparty exposure (current, potential future, expected positive), credit limits, CVA/DVA pricing, ISDA netting agreements, and CSA collateral management
+   - `CurrentExposure`, `PotentialFutureExposure()`, `ExpectedPositiveExposure`, `CVA`, `DVA`, `NettingBenefit`, `CreditLimit`, `CollateralHaircut`
+
+3. [Liquidity and Operational Risk](03_Liquidity-And-Operational-Risk.md) — Bid-ask spread cost, market depth/impact models, liquidation horizon, liquidity-adjusted VaR, concentration risk metrics, and operational risk controls for trade errors and fat-finger prevention
+   - `SpreadCost`, `MarketImpact()`, `LiquidationHorizon`, `LiquidityAdjustedVaR`, `LCR`, `NSFR`, `FatFingerCheck`, `DuplicateDetection`
+
+4. [Pre-Trade Risk Controls](04_Pre-Trade-Risk-Controls.md) — Synchronous order validation pipeline: price reasonability, size limits, position limits, credit/margin checks, concentration checks, message rate throttling, and duplicate detection
+   - `OrderValidation`, `PriceReasonabilityCheck()`, `PositionLimitCheck()`, `NotionalLimit`, `MessageRateThrottle`, `DuplicateCheck`, `OrderToTradeRatio`
+
+5. [Real-Time Risk Calculations: Options Greeks](05_Real-Time-Risk-Calculations-Options-Greeks.md) — Black-Scholes Greeks (delta, gamma, vega, theta, rho), portfolio-level aggregation, dollar gamma, gamma P&L, and vega surface matrices
+   - `Delta`, `Gamma`, `Vega`, `Theta`, `Rho`, `PortfolioDelta`, `DollarGamma`, `GammaPnL`, `VegaMatrix`
+
+6. [Real-Time Risk Calculations: Fixed Income and Architecture](06_Real-Time-Risk-Calculations-Fixed-Income-And-Architecture.md) — DV01/PV01, key rate DV01s, credit spread duration (CS01), convexity, beta exposure, and the real-time risk calculation architecture with latency targets
+   - `DV01`, `PV01`, `KeyRateDV01`, `CS01`, `SpreadDuration`, `Convexity`, `PortfolioBeta`, `RiskAggregationEngine`
+
+7. [Risk Limits and Breaches](07_Risk-Limits-And-Breaches.md) — Limit hierarchy (board to trader), hard vs. soft limits, utilization monitoring, breach classification (active/passive/technical), escalation workflows, stop-loss limits, and limit dashboards
+   - `LimitHierarchy`, `LimitUtilization`, `BreachEscalation`, `ActiveBreach`, `PassiveBreach`, `StopLossLimit`, `LimitDashboard`
+
+8. [Stress Testing and Scenario Analysis](08_Stress-Testing-And-Scenario-Analysis.md) — Historical and hypothetical stress scenarios, reverse stress testing, sensitivity analysis (bump-and-reprice), and stress testing governance
+   - `HistoricalScenario`, `HypotheticalScenario`, `ReverseStressTest()`, `BumpAndReprice()`, `SensitivityGrid`, `StressLossLimit`
+
+9. [Regulatory Risk Requirements](09_Regulatory-Risk-Requirements.md) — Basel III/IV capital framework, FRTB standardized and internal models approaches, P&L attribution test, ISDA SIMM for non-cleared derivative initial margin, and risk-weighted assets
+   - `CET1`, `RiskWeightedAssets`, `FRTB_SA`, `FRTB_IMA`, `ExpectedShortfall`, `DefaultRiskCharge`, `PLAttributionTest`, `ISDA_SIMM`
+
+10. [Risk Attribution and Factor Models](10_Risk-Attribution-Factor-Models.md) — Factor-based risk decomposition (Barra/MSCI style factors, fixed income factors), sector/country/style risk attribution, and systematic vs. idiosyncratic risk
+    - `FactorModel`, `FactorExposure`, `FactorCovariance`, `IdiosyncraticRisk`, `SectorDecomposition`, `CountryDecomposition`, `StyleDecomposition`
+
+11. [Risk Attribution: Marginal and Component](11_Risk-Attribution-Marginal-And-Component.md) — Marginal VaR, component VaR, incremental VaR, risk attribution over time (day-over-day VaR change), and the risk reporting hierarchy
+    - `MarginalVaR`, `ComponentVaR`, `IncrementalVaR`, `VaRChangeAttribution`, `RiskReportingHierarchy`
+
+12. [Appendices](12_Appendices.md) — VaR backtesting methodology (Kupiec POF test, Christoffersen independence test, Basel traffic light system) and key formulas reference
+    - `Backtest`, `KupiecPOF`, `ChristoffersenIndependence`, `BaselTrafficLight`, `FormulaReference`

--- a/docs/trading-desk/06-connectivity-and-protocols/README.md
+++ b/docs/trading-desk/06-connectivity-and-protocols/README.md
@@ -4,14 +4,35 @@ Comprehensive reference for network connectivity, messaging protocols, data feed
 
 ## Contents
 
-1. [FIX Protocol](01_FIX-Protocol.md)
-2. [FIX Engines and Session Management](02_FIX-Engines-And-Session-Management.md)
-3. [Market Data Protocols](03_Market-Data-Protocols.md)
-4. [Network Connectivity](04_Network-Connectivity.md)
-5. [Message Queuing and Middleware](05_Message-Queuing-And-Middleware.md)
-6. [API Integrations](06_API-Integrations.md)
-7. [Drop Copy and Trade Reporting](07_Drop-Copy-And-Trade-Reporting.md)
-8. [SWIFT Messaging](08_SWIFT-Messaging.md)
-9. [Data Feeds and Vendors](09_Data-Feeds-And-Vendors.md)
-10. [Straight Through Processing (STP)](10_Straight-Through-Processing.md)
-11. [Gateway and Adapter Architecture](11_Gateway-And-Adapter-Architecture.md)
+1. [FIX Protocol](01_FIX-Protocol.md) — FIX version history, session layer (FIXT 1.1) and application layer architecture, message types for order flow / market data / post-trade, key tag reference, and tag=value wire format
+   - `NewOrderSingle`, `ExecutionReport`, `OrderCancelReplaceRequest`, `MarketDataRequest`, `TradeCaptureReport`, `SenderCompID`, `MsgSeqNum`, `ResendRequest`, `ClOrdID`
+
+2. [FIX Engines and Session Management](02_FIX-Engines-And-Session-Management.md) — Major FIX engines (QuickFIX family, commercial, FPGA-accelerated), session configuration, lifecycle (logon through logout), sequence number persistence and gap recovery, and production monitoring
+   - `FIXEngine`, `SessionConfig`, `SequenceNumber`, `ResendRequest`, `GapFill`, `HeartBtInt`, `PossDupFlag`, `ResetSeqNumFlag`
+
+3. [Market Data Protocols](03_Market-Data-Protocols.md) — Binary market data protocols (FAST, SBE, ITCH, OUCH, PITCH), proprietary exchange protocols, UDP multicast architecture, recovery mechanisms, and consolidated vs. direct feeds
+   - `FAST`, `SBE`, `ITCH`, `OUCH`, `PITCH`, `MoldUDP64`, `MulticastPublisher`, `LineArbitration`, `SIP`, `DirectFeed`
+
+4. [Network Connectivity](04_Network-Connectivity.md) — Dedicated lines, cross-connects, co-location and proximity hosting, microwave/millimeter-wave/laser links, and key low-latency network routes
+   - `CrossConnect`, `CoLocation`, `ProximityHosting`, `DarkFiber`, `DWDM`, `MicrowaveLink`, `FreqSpaceLaser`
+
+5. [Message Queuing and Middleware](05_Message-Queuing-And-Middleware.md) — Messaging platforms (Solace, TIBCO RV, Kafka, ZeroMQ, Aeron, Chronicle Queue, LMAX Disruptor), pub/sub patterns, guaranteed delivery, and topic hierarchies
+   - `PubSub`, `GuaranteedDelivery`, `TopicHierarchy`, `Aeron`, `ZeroMQ`, `Kafka`, `Solace`, `ChronicleQueue`, `LMAXDisruptor`
+
+6. [API Integrations](06_API-Integrations.md) — REST, WebSocket, and gRPC integration patterns; Bloomberg BLPAPI (B-PIPE, Desktop API, EMSX); Refinitiv/LSEG real-time APIs (Elektron, RDP); and other vendor data APIs
+   - `BLPAPI`, `BPIPE`, `EMSX`, `WebSocketAPI`, `gRPC`, `ElektronSDK`, `RefinitivDataPlatform`, `RESTEndpoint`
+
+7. [Drop Copy and Trade Reporting](07_Drop-Copy-And-Trade-Reporting.md) — Drop copy sessions for independent execution monitoring, and regulatory trade reporting (TRACE, CAT, MiFID II APA/ARM, FpML, ISO 20022)
+   - `DropCopy`, `ExecutionReport`, `TradeCaptureReport`, `TRACE`, `CAT`, `APA`, `ARM`, `FpML`
+
+8. [SWIFT Messaging](08_SWIFT-Messaging.md) — MT message categories (securities settlement MT5xx, payments MT1xx/2xx, treasury MT3xx), ISO 20022 MX migration, and SWIFT infrastructure (SWIFTNet, Alliance, gpi)
+   - `MT540`, `MT535`, `MT103`, `MT300`, `MX_sese023`, `MX_pacs008`, `ISO20022`, `SWIFTNet`, `UETR`
+
+9. [Data Feeds and Vendors](09_Data-Feeds-And-Vendors.md) — Major data vendors (Bloomberg, Refinitiv/LSEG, ICE, FactSet, S&P), specialized providers, and data quality management (symbology mapping, corporate actions, entitlements)
+   - `BloombergTerminal`, `BPIPE`, `ElektronFeed`, `ICEConsolidatedFeed`, `SymbologyMapping`, `ReferenceDataMastering`, `EntitlementManagement`
+
+10. [Straight Through Processing](10_Straight-Through-Processing.md) — End-to-end trade automation from execution through settlement: trade capture, confirmation/matching (DTCC CTM), allocation, clearing (CCP), settlement (CSD), and STP rate targets
+    - `STPWorkflow`, `TradeConfirmation`, `DTCC_CTM`, `SettlementInstruction`, `SSI`, `CCP`, `CSD`, `STPRate`
+
+11. [Gateway and Adapter Architecture](11_Gateway-And-Adapter-Architecture.md) — Gateway/adapter abstraction layer, protocol translation, DMA vs. sponsored access, broker adapters for algo routing/SOR, feed handler architecture (line arbitration, book building), and multi-venue connectivity management
+    - `ExchangeGateway`, `BrokerAdapter`, `ProtocolTranslation`, `SymbolMapping`, `OrderIdMapping`, `FeedHandler`, `LineArbitrator`, `BookBuilder`, `CircuitBreaker`

--- a/docs/trading-desk/07-infrastructure-and-architecture/README.md
+++ b/docs/trading-desk/07-infrastructure-and-architecture/README.md
@@ -4,9 +4,20 @@ Comprehensive reference for infrastructure patterns, system architecture, deploy
 
 ## Contents
 
-1. [Low-Latency Architecture and Event-Driven Architecture](01_Low-Latency-Architecture-And-Event-Driven-Architecture.md)
-2. [High Availability and System Monitoring](02_High-Availability-And-System-Monitoring.md)
-3. [Capacity Planning and Database Considerations](03_Capacity-Planning-And-Database-Considerations.md)
-4. [Security and Configuration Management](04_Security-And-Configuration-Management.md)
-5. [Deployment and Scalability Patterns](05_Deployment-And-Scalability-Patterns.md)
-6. [Cloud vs On-Premise Considerations](06_Cloud-Vs-On-Premise-Considerations.md)
+1. [Low-Latency Architecture and Event-Driven Architecture](01_Low-Latency-Architecture-And-Event-Driven-Architecture.md) — Kernel bypass networking, lock-free data structures, memory-mapped IPC, and event sourcing with CQRS patterns
+   - `sched_setaffinity()`, `mmap()`, `SPSCQueue`, `LMAXDisruptor`, `EventStore`, `CommandHandler`, `ReadModelProjection`
+
+2. [High Availability and System Monitoring](02_High-Availability-And-System-Monitoring.md) — Active-active/passive failover topologies, RTO/RPO targets, and monitoring stacks for trading infrastructure
+   - `FailoverManager`, `HealthCheck`, `FIXSessionFailover`, `AlertSeverity`, `SLATracker`, `RunbookEntry`
+
+3. [Capacity Planning and Database Considerations](03_Capacity-Planning-And-Database-Considerations.md) — Throughput budgets, exchange rate limits, time-series databases (kdb+, QuestDB), relational stores, and in-memory caching layers
+   - `LatencyBudget`, `RateLimiter`, `TokenBucket`, `TimeSeriesStore`, `InstrumentCache`, `PositionCache`, `PriceCache`
+
+4. [Security and Configuration Management](04_Security-And-Configuration-Management.md) — Network segmentation zones, encryption layers, RBAC/entitlements, audit logging, and instrument/risk-limit configuration management
+   - `NetworkZone`, `RBACPolicy`, `AuditLog`, `InstrumentConfig`, `RiskLimitFramework`, `AlgoParameterSet`, `UserPermission`
+
+5. [Deployment and Scalability Patterns](05_Deployment-And-Scalability-Patterns.md) — Blue-green and canary deployment strategies, market-hours release windows, and horizontal scaling via instrument/exchange/desk partitioning
+   - `BlueGreenDeploy`, `CanaryRelease`, `FeatureFlag`, `OrderRouter`, `PartitionByInstrument`, `MarketDataFanOut`
+
+6. [Cloud vs On-Premise Considerations](06_Cloud-Vs-On-Premise-Considerations.md) — Latency trade-offs per workload, hybrid co-location/cloud architectures, regulatory constraints, and emerging trends (FPGA-as-a-Service, confidential computing)
+   - `HybridArchitecture`, `CoLocationGateway`, `DirectConnect`, `DataResidencyPolicy`, `ConcentrationRiskAssessment`

--- a/docs/trading-desk/08-equities-trading/README.md
+++ b/docs/trading-desk/08-equities-trading/README.md
@@ -4,9 +4,20 @@ Comprehensive reference for equity asset-class features on a professional tradin
 
 ## Contents
 
-1. [Cash Equities Trading](01_Cash-Equities-Trading.md)
-2. [Equity Market Structure](02_Equity-Market-Structure.md)
-3. [IPO Offerings and Short Selling](03_IPO-Offerings-And-Short-Selling.md)
-4. [Index Trading, Blocks, and Swaps](04_Index-Trading-Blocks-And-Swaps.md)
-5. [Program Trading and Market Making](05_Program-Trading-And-Market-Making.md)
-6. [Trading Considerations and Data Requirements](06_Trading-Considerations-And-Data-Requirements.md)
+1. [Cash Equities Trading](01_Cash-Equities-Trading.md) — Instrument types (stocks, ETFs, ADRs, REITs), order type taxonomy, and execution semantics for a professional equity OMS
+   - `MarketOrder`, `LimitOrder`, `PeggedOrder`, `ReserveOrder`, `IOC`, `FOK`, `MOC`, `LOC`, `ETFCreationRedemption`, `ADRArbitrage`
+
+2. [Equity Market Structure](02_Equity-Market-Structure.md) — Reg NMS rules, exchange/ECN/dark-pool venues, auction mechanisms (open, close, IPO/halt), and OTC wholesale market making
+   - `OrderProtectionRule`, `DarkPool`, `MidpointMatch`, `OpeningAuction`, `ClosingAuction`, `VolatilityAuction`, `NBBO`, `ATSFormN`
+
+3. [IPO Offerings and Short Selling](03_IPO-Offerings-And-Short-Selling.md) — IPO book-building and allocation workflows, secondary offerings, short-locate/borrow mechanics, Reg SHO compliance, and recall risk
+   - `IPOAllocation`, `LocateRequest`, `BorrowRate`, `HardToBorrowList`, `ShortInterestRatio`, `RegSHOCircuitBreaker`, `BuyInProcess`
+
+4. [Index Trading, Blocks, and Swaps](04_Index-Trading-Blocks-And-Swaps.md) — Index futures basis/roll, ETF-futures arbitrage, block trading protocols, and equity swap structures (TRS, CFD, portfolio swaps)
+   - `IndexFuture`, `FairValueCalc`, `RollSpread`, `IndexArbitrage`, `BlockTrade`, `TotalReturnSwap`, `CFD`, `PortfolioSwap`
+
+5. [Program Trading and Market Making](05_Program-Trading-And-Market-Making.md) — Basket execution and transition management, portfolio rebalancing optimization, and market-maker quoting obligations and inventory management
+   - `ProgramTrade`, `BasketExecution`, `RebalanceOptimizer`, `TransitionManager`, `DesignatedMarketMaker`, `InventorySkew`, `AdverseSelection`
+
+6. [Trading Considerations and Data Requirements](06_Trading-Considerations-And-Data-Requirements.md) — Small-cap vs large-cap execution strategies, extended-hours session handling, and key data feeds for an equities platform
+   - `SmallCapExecutionStrategy`, `ExtendedHoursSession`, `PreMarketOrder`, `GapRisk`, `MarketDataFeed`, `CorporateActionFeed`, `ShortLocateFeed`

--- a/docs/trading-desk/09-fixed-income-trading/README.md
+++ b/docs/trading-desk/09-fixed-income-trading/README.md
@@ -4,9 +4,20 @@ Comprehensive reference for fixed income asset-class features on a professional 
 
 ## Contents
 
-1. [Bond Trading and Market Structure](01_Bond-Trading-And-Market-Structure.md)
-2. [Yield Curve Analysis and Credit Trading](02_Yield-Curve-Analysis-And-Credit-Trading.md)
-3. [Interest Rate Derivatives and Repo](03_Interest-Rate-Derivatives-And-Repo.md)
-4. [Money Markets and Mortgage-Backed Securities](04_Money-Markets-And-Mortgage-Backed-Securities.md)
-5. [Fixed Income Analytics](05_Fixed-Income-Analytics.md)
-6. [Electronic Trading and RFQ Workflows](06_Electronic-Trading-And-RFQ-Workflows.md)
+1. [Bond Trading and Market Structure](01_Bond-Trading-And-Market-Structure.md) — Government, corporate, municipal, and agency bond types; dealer-to-client and dealer-to-dealer market structure; electronic trading platforms (Tradeweb, MarketAxess, BrokerTec)
+   - `TreasuryNote`, `CorporateBond`, `MunicipalBond`, `AgencyBond`, `CallableBond`, `ConvertibleBond`, `TRACEReport`, `RFQProtocol`, `CLOBMatch`
+
+2. [Yield Curve Analysis and Credit Trading](02_Yield-Curve-Analysis-And-Credit-Trading.md) — Curve bootstrapping, interpolation methods, multi-curve framework, flattener/steepener/butterfly strategies, IG/HY/distressed credit, and CDS indices (CDX/iTraxx)
+   - `CurveBootstrap`, `CubicSplineInterp`, `NelsonSiegelModel`, `FlattenerTrade`, `ButterflyTrade`, `CarryRollDown`, `CreditDefaultSwap`, `CDXIndex`, `iTraxxXover`
+
+3. [Interest Rate Derivatives and Repo](03_Interest-Rate-Derivatives-And-Repo.md) — Vanilla and basis IRS, swaptions, caps/floors, FRAs, SOFR transition mechanics, and repo structures (overnight, term, tri-party, GC vs special)
+   - `InterestRateSwap`, `BasisSwap`, `PayerSwaption`, `ReceiverSwaption`, `Cap`, `Floor`, `FRA`, `RepoTrade`, `TriPartyRepo`, `DollarRoll`
+
+4. [Money Markets and Mortgage-Backed Securities](04_Money-Markets-And-Mortgage-Backed-Securities.md) — T-bills, commercial paper, CDs, fed funds; agency MBS pass-throughs, CMO tranches (PAC, IO/PO, Z-tranche), TBA trading, and prepayment modeling
+   - `TreasuryBill`, `CommercialPaper`, `NegotiableCD`, `MoneyMarketFund`, `MBSPassThrough`, `CMOTranche`, `TBATrade`, `DollarRoll`, `PrepaymentModel`, `CPR`, `PSAModel`
+
+5. [Fixed Income Analytics](05_Fixed-Income-Analytics.md) — Duration (Macaulay, modified, effective, key-rate), convexity, spread measures (G-spread, Z-spread, OAS, ASW, CDS-bond basis), and rich/cheap relative-value analysis
+   - `MacaulayDuration`, `ModifiedDuration`, `EffectiveDuration`, `KeyRateDuration`, `DV01`, `Convexity`, `ZSpread`, `OAS`, `AssetSwapSpread`, `CDSBondBasis`
+
+6. [Electronic Trading and RFQ Workflows](06_Electronic-Trading-And-RFQ-Workflows.md) — RFQ lifecycle and optimization, all-to-all and portfolio trading protocols, click-to-trade streaming, composite pricing, and transaction cost analysis (TCA)
+   - `RFQWorkflow`, `DealerPricingEngine`, `AllToAllMatch`, `PortfolioTrade`, `ClickToTrade`, `CompositePrice`, `TransactionCostAnalysis`, `LiquidityScore`

--- a/docs/trading-desk/10-fx-and-commodities-trading/README.md
+++ b/docs/trading-desk/10-fx-and-commodities-trading/README.md
@@ -4,9 +4,20 @@ Comprehensive reference for foreign exchange and commodities asset-class feature
 
 ## Contents
 
-1. [FX Spot, Forwards, and Swaps](01_FX-Spot-Forwards-And-Swaps.md)
-2. [FX Options and Market Structure](02_FX-Options-And-Market-Structure.md)
-3. [FX Prime Brokerage, Fixing, and Algo Execution](03_FX-Prime-Brokerage-Fixing-And-Algo-Execution.md)
-4. [Energy and Metals Trading](04_Energy-And-Metals-Trading.md)
-5. [Agricultural Commodities, Futures, and Physical Trading](05_Agricultural-Commodities-Futures-And-Physical-Trading.md)
-6. [Commodity Risk and Data Requirements](06_Commodity-Risk-And-Data-Requirements.md)
+1. [FX Spot, Forwards, and Swaps](01_FX-Spot-Forwards-And-Swaps.md) — Spot FX trading mechanics, currency pair classification, settlement via CLS, forward rate calculation, NDFs, FX swaps, and cross-currency basis swaps
+   - `ForwardRate()`, `NDFSettlement()`, `CurrencyPair`, `SwapPoints`, `CrossCurrencyBasis`, `TomNextRoll()`
+
+2. [FX Options and Market Structure](02_FX-Options-And-Market-Structure.md) — Vanilla and barrier FX options, digital/binary options, accumulators, ECN/SDP market structure, last-look mechanics, and price aggregation
+   - `BarrierOption`, `KnockInKnockOut`, `DigitalOption`, `RiskReversal`, `Butterfly`, `VolSurface`, `PriceAggregator`
+
+3. [FX Prime Brokerage, Fixing, and Algo Execution](03_FX-Prime-Brokerage-Fixing-And-Algo-Execution.md) — FXPB give-up mechanics, credit intermediation, WM/Reuters and Tokyo fixing rates, and FX algo strategies (TWAP, VWAP, IS, pegged, fixing-targeted)
+   - `GiveUp()`, `FixingRate`, `TWAP`, `VWAP`, `ImplementationShortfall`, `AlgoTCA`, `SpreadCapture`
+
+4. [Energy and Metals Trading](04_Energy-And-Metals-Trading.md) — Crude oil (WTI/Brent), natural gas, power/electricity, emissions trading, precious metals (gold/silver), and base metals on the LME
+   - `CrackSpread`, `SparkSpread`, `ContangoBackwardation`, `LBMAGoldPrice`, `LMEPromptDate`, `CheapestToDeliver`
+
+5. [Agricultural Commodities, Futures, and Physical Trading](05_Agricultural-Commodities-Futures-And-Physical-Trading.md) — Grains, softs, livestock futures, commodity options (Asian, spread), swaps (fixed-for-floating, basis), and physical vs financial trading convergence
+   - `CommoditySwap`, `AsianOption`, `SpreadOption`, `ExchangeForPhysical()`, `PositionLimit`, `BasisRisk`
+
+6. [Commodity Risk and Data Requirements](06_Commodity-Risk-And-Data-Requirements.md) — Storage and carry cost modeling, delivery logistics, weather risk, seasonality, geopolitical/regulatory risk, and key data feeds for an FX/commodities platform
+   - `CostOfCarry()`, `ConvenienceYield`, `WeatherDerivative`, `SeasonalSpread`, `Incoterms`, `CalendarSpread`

--- a/docs/trading-desk/11-options-trading/README.md
+++ b/docs/trading-desk/11-options-trading/README.md
@@ -4,10 +4,23 @@ Professional trading desk reference covering options order types, strategies, pr
 
 ## Contents
 
-1. [Options Order Types and Chain Display](01_Options-Order-Types-And-Chain-Display.md)
-2. [Options Pricing Models](02_Options-Pricing-Models.md)
-3. [Greeks Calculation and Display](03_Greeks-Calculation-And-Display.md)
-4. [Volatility Surfaces and Exercise/Assignment](04_Volatility-Surfaces-And-Exercise-Assignment.md)
-5. [Options Market Making and Listed vs OTC](05_Options-Market-Making-And-Listed-Vs-OTC.md)
-6. [Exotic Options](06_Exotic-Options.md)
-7. [Strategy Builders and Portfolio Margining](07_Strategy-Builders-And-Portfolio-Margining.md)
+1. [Options Order Types and Chain Display](01_Options-Order-Types-And-Chain-Display.md) — Single-leg and multi-leg order types, vertical/horizontal/diagonal spreads, iron condors, butterflies, ratio spreads, collars, and professional options chain display
+   - `IronCondor`, `BullCallSpread`, `CalendarSpread`, `RatioBackspread`, `Collar`, `StrikeLadder`, `ExpirationGrid`
+
+2. [Options Pricing Models](02_Options-Pricing-Models.md) — Black-Scholes-Merton, binomial/trinomial trees, Monte Carlo simulation with variance reduction, Dupire local volatility, Heston stochastic volatility, and SABR model
+   - `BlackScholes()`, `BinomialTree`, `MonteCarloSimulation()`, `LocalVolatility()`, `HestonModel`, `SABRModel`, `QuasiRandomSequence`
+
+3. [Greeks Calculation and Display](03_Greeks-Calculation-And-Display.md) — First-order Greeks (delta, gamma, theta, vega, rho), second-order Greeks (charm, vanna, volga, speed, color), and professional multi-level Greeks display
+   - `Delta`, `Gamma`, `Theta`, `Vega`, `Rho`, `Charm`, `Vanna`, `Volga`, `DollarGamma()`, `ScenarioGreeks`
+
+4. [Volatility Surfaces and Exercise/Assignment](04_Volatility-Surfaces-And-Exercise-Assignment.md) — IV surface construction, SVI/SSVI parameterization, skew and term structure, arbitrage constraints, American/European/Bermudan exercise, auto-exercise, and pin risk
+   - `VolSurface`, `SVIFit()`, `ImpliedVolInversion()`, `ArbitrageConstraint`, `AutoExercise`, `PinRisk`, `EarlyExercise()`
+
+5. [Options Market Making and Listed vs OTC](05_Options-Market-Making-And-Listed-Vs-OTC.md) — Delta hedging, gamma scalping, volatility and skew trading, dispersion trades, listed exchange routing, SPX/VIX specifics, and ISDA/CSA OTC documentation
+   - `DeltaHedge()`, `GammaScalp()`, `VarianceSwap`, `DispersionTrade`, `ComplexOrderBook`, `ISDAMasterAgreement`, `CreditSupportAnnex`
+
+6. [Exotic Options](06_Exotic-Options.md) — Path-independent exotics (digitals, compound, chooser), path-dependent exotics (Asian, lookback, barrier, quanto, rainbow, basket options), and hedging approaches
+   - `AsianOption`, `LookbackOption`, `BarrierOption`, `QuantoAdjustment()`, `RainbowOption`, `BasketOption`, `CompoundOption`
+
+7. [Strategy Builders and Portfolio Margining](07_Strategy-Builders-And-Portfolio-Margining.md) — Visual strategy construction, payoff diagrams, probability/scenario analysis, SPAN margining, OCC portfolio margin, Reg-T vs portfolio margin comparison, and cross-margining
+   - `PayoffDiagram`, `ProbabilityOfProfit()`, `ScenarioGrid`, `SPANMargin()`, `PortfolioMargin`, `CrossMargin`, `MarginCall`

--- a/docs/trading-desk/12-futures-and-listed-derivatives/README.md
+++ b/docs/trading-desk/12-futures-and-listed-derivatives/README.md
@@ -4,9 +4,20 @@ Professional trading desk reference covering futures trading, market structure, 
 
 ## Contents
 
-1. [Futures Trading and Market Structure](01_Futures-Trading-And-Market-Structure.md)
-2. [Futures Roll Management and Spreads](02_Futures-Roll-Management-And-Spreads.md)
-3. [Clearing, Margining, and Settlement](03_Clearing-Margining-And-Settlement.md)
-4. [ETFs, ETNs, and Structured Products](04_ETFs-ETNs-And-Structured-Products.md)
-5. [Cryptocurrency Derivatives](05_Cryptocurrency-Derivatives.md)
-6. [Cross-Margining and Basis Trading](06_Cross-Margining-And-Basis-Trading.md)
+1. [Futures Trading and Market Structure](01_Futures-Trading-And-Market-Structure.md) — Contract specifications, tick value and P&L calculation, margin requirements, daily mark-to-market settlement, and exchange structure (CME Group, ICE, Eurex, SGX)
+   - `ContractSpec`, `TickValue()`, `InitialMargin`, `MaintenanceMargin`, `MarkToMarket()`, `SettlementPrice`, `ImpliedOrder`
+
+2. [Futures Roll Management and Spreads](02_Futures-Roll-Management-And-Spreads.md) — Roll scheduling, volume/OI crossover detection, continuous contract construction (back-adjusted, ratio-adjusted), roll yield, and inter-commodity spreads (crack, crush, spark, NOB)
+   - `CalendarSpread`, `RollYield()`, `ContinuousContract`, `CrackSpread`, `CrushSpread`, `SparkSpread`, `FlySpread`
+
+3. [Clearing, Margining, and Settlement](03_Clearing-Margining-And-Settlement.md) — CCP clearing mechanics, SPAN/PRISMA/PAIRS margin models, variation margin, default waterfall, physical delivery process, cash settlement, and cheapest-to-deliver bond logic
+   - `CentralCounterparty`, `SPANMargin()`, `VariationMargin`, `DefaultWaterfall`, `PhysicalDelivery`, `CashSettlement`, `CheapestToDeliver()`
+
+4. [ETFs, ETNs, and Structured Products](04_ETFs-ETNs-And-Structured-Products.md) — ETF creation/redemption and NAV tracking, ETN credit risk, warrants, structured certificates (bonus, discount, express), turbo knock-out warrants, and CFDs
+   - `CreationRedemption()`, `AuthorizedParticipant`, `IndicativeNAV`, `TurboWarrant`, `StructuredCertificate`, `CFD`, `KnockOutBarrier`
+
+5. [Cryptocurrency Derivatives](05_Cryptocurrency-Derivatives.md) — CME Bitcoin/Ether futures and options, perpetual swap funding rate mechanism, liquidation engine, mark price, and Deribit options ecosystem
+   - `PerpetualSwap`, `FundingRate()`, `LiquidationEngine`, `MarkPrice`, `BitcoinFutures`, `MicroContract`, `InsuranceFund`
+
+6. [Cross-Margining and Basis Trading](06_Cross-Margining-And-Basis-Trading.md) — CME-OCC and CME-LCH cross-margin programs, Eurex PRISMA, futures basis and fair value calculation, cash-and-carry arbitrage, index arbitrage, and bond basis trading
+   - `CrossMargin`, `BasisTrade`, `FairValue()`, `CashAndCarryArbitrage()`, `IndexArbitrage`, `BondBasis`, `ConversionFactor`

--- a/docs/trading-desk/13-post-trade-processing/README.md
+++ b/docs/trading-desk/13-post-trade-processing/README.md
@@ -4,8 +4,17 @@ Covers the post-trade processing features found in professional trading desk app
 
 ## Contents
 
-1. [Trade Confirmation and Clearing/Settlement](01_Trade-Confirmation-And-Clearing-Settlement.md)
-2. [Trade Allocation and Corporate Actions](02_Trade-Allocation-And-Corporate-Actions.md)
-3. [Reconciliation and Trade Lifecycle Events](03_Reconciliation-And-Trade-Lifecycle-Events.md)
-4. [Custody, Asset Servicing, and Tax Reporting](04_Custody-Asset-Servicing-And-Tax-Reporting.md)
-5. [STP, Exception Management, Middle Office, and Glossary](05_STP-Exception-Management-Middle-Office-And-Glossary.md)
+1. [Trade Confirmation and Clearing/Settlement](01_Trade-Confirmation-And-Clearing-Settlement.md) — Trade matching, electronic confirmations, CCP/bilateral clearing, settlement cycles, and CSD interactions
+   - `TradeMatching`, `ElectronicConfirmation`, `matchTrade()`, `CCPClearing`, `novation()`, `calculateInitialMargin()`, `calculateVariationMargin()`, `netSettlementObligations()`, `SettlementCycle`
+
+2. [Trade Allocation and Corporate Actions](02_Trade-Allocation-And-Corporate-Actions.md) — Block trade allocation, step-outs/give-ups, average pricing, and mandatory/voluntary corporate action processing
+   - `BlockAllocation`, `allocateBlock()`, `StepOutTrade`, `GiveUpTrade`, `calculateAveragePrice()`, `CorporateAction`, `processDividend()`, `processStockSplit()`, `ElectionManager`, `RecordDateEntitlement`
+
+3. [Reconciliation and Trade Lifecycle Events](03_Reconciliation-And-Trade-Lifecycle-Events.md) — Trade, position, and cash reconciliation, breaks management, and trade amendments/cancellations/corrections
+   - `TradeReconciliation`, `PositionReconciliation`, `CashReconciliation`, `BreaksManager`, `categorizeBreak()`, `ageBreak()`, `TradeAmendment`, `TradeCancellation`, `TradeCorrection`, `matchRecords()`
+
+4. [Custody, Asset Servicing, and Tax Reporting](04_Custody-Asset-Servicing-And-Tax-Reporting.md) — Custodian interactions, SWIFT messaging, income collection, wash sale tracking, tax lot accounting, and 1099/W-8BEN reporting
+   - `CustodianInterface`, `SWIFTMessage`, `IncomeCollection`, `WashSaleDetector`, `TaxLotAccounting`, `selectTaxLot()`, `calculateCostBasis()`, `generate1099()`, `W8BENValidator`, `WithholdingTaxCalculator`
+
+5. [STP, Exception Management, Middle Office, and Glossary](05_STP-Exception-Management-Middle-Office-And-Glossary.md) — STP rate measurement and enhancement, exception management workflows, trade validation/enrichment/booking, and P&L attribution
+   - `STPRateCalculator`, `ExceptionManager`, `routeException()`, `TradeValidator`, `TradeEnrichment`, `enrichSettlementInstructions()`, `TradeBooking`, `bookTrade()`, `PnLAttribution`, `validatePnL()`

--- a/docs/trading-desk/14-compliance-and-regulatory/README.md
+++ b/docs/trading-desk/14-compliance-and-regulatory/README.md
@@ -4,14 +4,35 @@ Covers the compliance, regulatory reporting, and market access control features 
 
 ## Contents
 
-1. [Pre-Trade Compliance](01_Pre-Trade-Compliance.md)
-2. [Trade Surveillance](02_Trade-Surveillance.md)
-3. [Regulatory Reporting](03_Regulatory-Reporting.md)
-4. [Best Execution Monitoring and Reporting](04_Best-Execution-Monitoring-And-Reporting.md)
-5. [Record Keeping Requirements](05_Record-Keeping-Requirements.md)
-6. [Short Selling Regulations](06_Short-Selling-Regulations.md)
-7. [Market Access Controls](07_Market-Access-Controls.md)
-8. [AML/KYC in Trading Context](08_AML-KYC-In-Trading-Context.md)
-9. [Position Reporting](09_Position-Reporting.md)
-10. [Cross-Border Trading Regulations](10_Cross-Border-Trading-Regulations.md)
-11. [Glossary of Key Acronyms](11_Glossary-Of-Key-Acronyms.md)
+1. [Pre-Trade Compliance](01_Pre-Trade-Compliance.md) — Restricted/watch lists, insider trading prevention, information barriers, and personal account dealing controls
+   - `RestrictedList`, `WatchList`, `checkRestrictedList()`, `InformationBarrier`, `WallCrossingEvent`, `InsiderList`, `PersonalAccountDealingRequest`, `preClearPersonalTrade()`, `BlackoutPeriod`
+
+2. [Trade Surveillance](02_Trade-Surveillance.md) — Real-time detection of market manipulation, spoofing/layering, wash trading, front-running, and cross-trading monitoring
+   - `SurveillanceEngine`, `detectSpoofing()`, `detectLayering()`, `detectWashTrading()`, `detectFrontRunning()`, `CrossTradeMonitor`, `AlertWorkflow`, `SuspiciousActivityReport`, `OrderToTradeRatio`, `CancelToFillRatio`
+
+3. [Regulatory Reporting](03_Regulatory-Reporting.md) — MiFIR transaction reporting, EMIR/Dodd-Frank derivative reporting, CAT audit trail, SFTR, and SEC Rule 606 order routing disclosure
+   - `MiFIRTransactionReport`, `EMIRTradeReport`, `DoddFrankSwapReport`, `CATEventReport`, `SFTRReport`, `Rule606Report`, `UniqueTradeIdentifier`, `UniqueProductIdentifier`, `submitToARM()`, `submitToSDR()`
+
+4. [Best Execution Monitoring and Reporting](04_Best-Execution-Monitoring-And-Reporting.md) — Execution quality metrics, venue analysis, toxicity measurement, and RTS 27/28 report generation
+   - `ExecutionQualityAnalyzer`, `calculateImplementationShortfall()`, `calculateVWAPSlippage()`, `VenueAnalysis`, `ToxicityAnalysis`, `RTS28Report`, `BestExecutionPolicy`, `measurePriceImprovement()`, `ReversionAnalysis`
+
+5. [Record Keeping Requirements](05_Record-Keeping-Requirements.md) — Order/trade record retention, communication recording (voice and electronic), clock synchronization, and WORM storage compliance
+   - `OrderRecord`, `TradeRecord`, `CommunicationRecorder`, `VoiceRecording`, `ElectronicCommunicationArchive`, `ClockSynchronizer`, `RetentionPolicy`, `WORMStorage`, `retrieveRecord()`
+
+6. [Short Selling Regulations](06_Short-Selling-Regulations.md) — Locate requirements, Regulation SHO compliance, short sale circuit breaker (Rule 201), and short position reporting
+   - `LocateManager`, `obtainLocate()`, `EasyToBorrowList`, `RegSHOCompliance`, `closeOutFailToDeliver()`, `ShortSaleCircuitBreaker`, `enforceUptickRule()`, `ThresholdSecurityList`, `ShortPositionReport`
+
+7. [Market Access Controls](07_Market-Access-Controls.md) — SEC Rule 15c3-5 risk controls, kill switch, rate limiters, self-trade prevention, and erroneous trade prevention
+   - `MarketAccessRiskControl`, `PreTradeRiskCheck`, `KillSwitch`, `activateKillSwitch()`, `RateLimiter`, `SelfTradePreventor`, `PriceCollar`, `LULDEnforcer`, `FatFingerProtection`, `DuplicateOrderDetector`
+
+8. [AML/KYC in Trading Context](08_AML-KYC-In-Trading-Context.md) — Suspicious activity monitoring and SAR/STR filing, sanctions screening against OFAC/EU/UN lists, and real-time counterparty screening
+   - `SuspiciousActivityMonitor`, `fileSAR()`, `fileSTR()`, `SanctionsScreener`, `screenCounterparty()`, `screenIssuer()`, `OFACSDNList`, `CurrencyTransactionReport`
+
+9. [Position Reporting](09_Position-Reporting.md) — SEC large trader reporting, CFTC position limits, 13F filings, and Schedule 13D/13G beneficial ownership disclosure
+   - `LargeTraderReport`, `LargeTraderID`, `CFTCPositionLimit`, `checkPositionLimit()`, `SEC13FReport`, `Schedule13D`, `Schedule13G`, `BeneficialOwnershipMonitor`, `alertOwnershipThreshold()`
+
+10. [Cross-Border Trading Regulations](10_Cross-Border-Trading-Regulations.md) — Jurisdiction-specific regulatory requirements (US, UK, EU, Singapore, Hong Kong, Australia) and cross-border implementation considerations
+    - `RegulatoryPerimeterMap`, `JurisdictionRuleSet`, `EquivalenceDetermination`, `DataLocalizationPolicy`, `MultiEntityBookingModel`, `RegulatoryChangeManager`, `TimezoneHandler`, `StockConnectCompliance`
+
+11. [Glossary of Key Acronyms](11_Glossary-Of-Key-Acronyms.md) — Reference table of 60+ acronyms used across compliance, regulatory reporting, and market access domains
+    - `ARM`, `CAT`, `CCP`, `EMIR`, `LEI`, `MiFIR`, `OFAC`, `SDR`, `SOR`, `SFTR`, `UTI`, `UPI`, `WORM`

--- a/docs/trading-desk/15-operational-workflows/README.md
+++ b/docs/trading-desk/15-operational-workflows/README.md
@@ -4,13 +4,32 @@ Covers operational workflows in professional trading desk applications including
 
 ## Contents
 
-1. [Start-of-Day Procedures](01_Start-of-Day-Procedures.md)
-2. [End-of-Day Procedures](02_End-of-Day-Procedures.md)
-3. [Trade Booking Workflows](03_Trade-Booking-Workflows.md)
-4. [Break Management and Exception Handling](04_Break-Management-and-Exception-Handling.md)
-5. [Batch Processing](05_Batch-Processing.md)
-6. [Market Event Handling](06_Market-Event-Handling.md)
-7. [Manual Intervention Workflows](07_Manual-Intervention-Workflows.md)
-8. [Client Onboarding for Trading](08_Client-Onboarding-for-Trading.md)
-9. [Disaster Recovery Procedures](09_Disaster-Recovery-Procedures.md)
-10. [Intraday Monitoring and Operational Dashboards](10_Intraday-Monitoring-and-Operational-Dashboards.md)
+1. [Start-of-Day Procedures](01_Start-of-Day-Procedures.md) — SOD position loading, system health checks, market data validation, risk limit loading, and reference data verification
+   - `SODPositionLoader`, `loadPositions()`, `SystemHealthCheck`, `MarketDataValidator`, `checkStaleness()`, `crossSourceValidation()`, `RiskLimitLoader`, `loadLimits()`, `ReferenceDataValidator`, `SODSignOff`
+
+2. [End-of-Day Procedures](02_End-of-Day-Procedures.md) — EOD P&L calculation, position reconciliation, trade matching, reporting generation, and NAV calculation
+   - `EODPnLCalculator`, `calculateRealizedPnL()`, `calculateUnrealizedPnL()`, `PositionReconciler`, `TradeMatchEngine`, `ReportGenerator`, `NAVCalculator`, `calculateNAV()`, `swingPricing()`, `PnLSignOff`
+
+3. [Trade Booking Workflows](03_Trade-Booking-Workflows.md) — Trade capture data model, trade enrichment rules, validation checks, and booking to books and accounts
+   - `Trade`, `TradeCaptureEngine`, `captureTrade()`, `TradeEnrichmentEngine`, `enrichSettlementDate()`, `enrichSSI()`, `TradeValidator`, `validatePrice()`, `validateDuplicate()`, `bookToLedger()`, `BookingStatus`
+
+4. [Break Management and Exception Handling](04_Break-Management-and-Exception-Handling.md) — Position/trade/cash break types, investigation workflows, resolution SLAs, aging escalation, failed trades, and rejected orders
+   - `BreakDetector`, `BreakInvestigator`, `categorizeBreak()`, `assignBreak()`, `BreakResolution`, `BreakAgingEscalator`, `FailedTradeHandler`, `RejectedOrderHandler`, `SettlementFailureWorkflow`, `CSDRPenaltyTracker`
+
+5. [Batch Processing](05_Batch-Processing.md) — Overnight batch sequencing (COB, settlement, corporate actions, reporting, system prep), settlement instruction generation, and data loads
+   - `BatchOrchestrator`, `COBProcessing`, `SettlementInstructionGenerator`, `generateSWIFTMessage()`, `NetSettlement`, `CorporateActionProcessor`, `RegulatoryReportGenerator`, `DataLoadValidator`, `BatchMonitor`, `batchFailureRecovery()`
+
+6. [Market Event Handling](06_Market-Event-Handling.md) — Trading halt detection and response, circuit breaker handling, exchange outage procedures, and early close management
+   - `TradingHaltHandler`, `detectHalt()`, `CircuitBreakerHandler`, `ExchangeOutageHandler`, `redirectSmartOrderRouter()`, `EarlyCloseManager`, `MarketCalendar`, `AlgoEndTimeAdjuster`, `OrderFreezeManager`
+
+7. [Manual Intervention Workflows](07_Manual-Intervention-Workflows.md) — Manual trade entry with four-eyes approval, trade amendments, off-market trade handling, and voice trade workflows
+   - `ManualTradeEntry`, `FourEyesApproval`, `TradeAmendmentWorkflow`, `OffMarketTradeDetector`, `VoiceTradeWorkflow`, `linkCallRecording()`, `AmendmentCutOff`, `OffMarketReasonCode`, `ComplianceReviewFlag`
+
+8. [Client Onboarding for Trading](08_Client-Onboarding-for-Trading.md) — Multi-phase client onboarding (CDD, legal docs, credit setup, operational setup, go-live), credit limit management, and margin agreements
+   - `ClientOnboarding`, `KYCCheck`, `SanctionsScreening`, `CreditLimitStructure`, `setCreditLimit()`, `MonitorCreditUtilization`, `MarginAgreement`, `calculateMarginCall()`, `CollateralManager`, `SSISetup`
+
+9. [Disaster Recovery Procedures](09_Disaster-Recovery-Procedures.md) — DR architecture (active-active/warm/cold), failover testing, backup site activation, and communication protocols
+   - `DisasterRecoveryPlan`, `RecoveryTimeObjective`, `RecoveryPointObjective`, `FailoverTest`, `executeSiteFailover()`, `validateDataConsistency()`, `BackupActivation`, `CommunicationPlan`, `IncidentEscalation`, `failback()`
+
+10. [Intraday Monitoring and Operational Dashboards](10_Intraday-Monitoring-and-Operational-Dashboards.md) — Pre-market through post-close monitoring checklists and real-time dashboards for system health, trading activity, risk, operations, and compliance
+    - `IntradayChecklist`, `PreMarketCheck`, `MidDayCheck`, `PreCloseCheck`, `PostCloseCheck`, `SystemHealthDashboard`, `TradingActivityDashboard`, `RiskOverviewDashboard`, `OperationsDashboard`, `ComplianceDashboard`

--- a/docs/trading-desk/16-trading-ui-components/README.md
+++ b/docs/trading-desk/16-trading-ui-components/README.md
@@ -4,9 +4,20 @@ Comprehensive reference for UI components found on professional trading desks, c
 
 ## Contents
 
-1. [Order Entry Tickets and Trading Blotter](01_Order-Entry-Tickets-And-Trading-Blotter.md)
-2. [Execution Blotter and Position Blotter](02_Execution-Blotter-And-Position-Blotter.md)
-3. [Market Data Displays](03_Market-Data-Displays.md)
-4. [Charting](04_Charting.md)
-5. [News, Research, and Alerts](05_News-Research-And-Alerts.md)
-6. [Workspace, Keyboard, and UX Patterns](06_Workspace-Keyboard-And-UX-Patterns.md)
+1. [Order Entry Tickets and Trading Blotter](01_Order-Entry-Tickets-And-Trading-Blotter.md) — Order entry forms for equities, options, FX, and fixed income with validation rules and keyboard shortcuts
+   - `OrderTicket`, `AlgoSubParameters`, `LegBuilder`, `FXStreamingQuote`, `RFQWorkflow`, `QuickTrade`, `FatFingerCheck`
+
+2. [Execution Blotter and Position Blotter](02_Execution-Blotter-And-Position-Blotter.md) — Per-fill execution reports, average price calculations, live P&L positions, and exposure heat maps
+   - `ExecutionBlotter`, `PartialFillAvgPrice()`, `ArrivalPriceSlippage`, `PositionBlotter`, `UnrealizedPnL`, `ExposureView`, `PositionHeatMap`
+
+3. [Market Data Displays](03_Market-Data-Displays.md) — Watchlists, quote boards, Level 2 market depth, and time-and-sales tape
+   - `Watchlist`, `QuoteBoard`, `MarketDepthDisplay`, `TimeAndSales`, `CumulativeDepth`, `ClickToTrade`, `SparklineChart`
+
+4. [Charting](04_Charting.md) — Chart types, timeframes, technical indicators, drawing tools, and multi-timeframe analysis
+   - `CandlestickChart`, `VolumeProfile`, `TechnicalIndicator`, `SMA`, `EMA`, `RSI`, `MACD`, `BollingerBands`, `FibonacciRetracement`, `DrawingLayer`, `CompareMode`
+
+5. [News, Research, and Alerts](05_News-Research-And-Alerts.md) — Real-time news feeds, sentiment indicators, economic calendar, and configurable alert/notification systems
+   - `NewsFeed`, `SentimentScore`, `EconomicCalendar`, `PriceAlert`, `VolumeAlert`, `TechnicalAlert`, `AlertConditionBuilder`, `NotificationChannel`
+
+6. [Workspace, Keyboard, and UX Patterns](06_Workspace-Keyboard-And-UX-Patterns.md) — Multi-monitor layouts, workspace save/load, symbol linking, keyboard-driven trading, and command palette
+   - `WorkspaceLayout`, `TearOffWindow`, `SymbolLinkGroup`, `DockingSystem`, `CommandPalette`, `HotkeyManager`, `PriceLadderDOM`, `KeybindingEditor`

--- a/docs/trading-desk/17-dashboard-and-analytics/README.md
+++ b/docs/trading-desk/17-dashboard-and-analytics/README.md
@@ -4,11 +4,26 @@ Comprehensive reference for dashboards, analytics, reporting, data visualization
 
 ## Contents
 
-1. [Real-Time Dashboards](01_Real-Time-Dashboards.md)
-2. [Portfolio Analytics](02_Portfolio-Analytics.md)
-3. [Performance Attribution](03_Performance-Attribution.md)
-4. [Reporting](04_Reporting.md)
-5. [Data Visualization](05_Data-Visualization.md)
-6. [Custom Analytics and Scripting](06_Custom-Analytics-And-Scripting.md)
-7. [Audit and Compliance Views](07_Audit-And-Compliance-Views.md)
-8. [Dashboard Design Principles](08_Dashboard-Design-Principles.md)
+1. [Real-Time Dashboards](01_Real-Time-Dashboards.md) — Live P&L, risk metrics, execution quality monitoring, and market overview dashboards
+   - `PnLDashboard`, `RiskDashboard`, `VaR`, `CVaR`, `ExecutionDashboard`, `VWAPSlippage`, `ScenarioAnalysis`, `GreeksSurface`, `RiskLimitMonitor`
+
+2. [Portfolio Analytics](02_Portfolio-Analytics.md) — Portfolio composition, sector and geographic allocation, factor exposure, and risk decomposition
+   - `HoldingsTable`, `SectorAllocation`, `GeographicExposure`, `FactorExposure`, `MarginalContributionToVaR`, `ActiveWeight`, `CurrencyExposure`
+
+3. [Performance Attribution](03_Performance-Attribution.md) — Brinson-Fachler return attribution, factor attribution, and transaction cost analysis
+   - `BrinsonAttribution`, `AllocationEffect()`, `SelectionEffect()`, `InteractionEffect()`, `FactorAttribution`, `ImplementationShortfall`, `TCABenchmark`
+
+4. [Reporting](04_Reporting.md) — End-of-day reports, trade confirmations, regulatory filings, and client-facing reports
+   - `DailyPnLReport`, `TradeConfirmation`, `RegulatoryReport`, `Form13F`, `CATReport`, `MiFIDTransactionReport`, `ClientFactsheet`, `CapitalAccountStatement`
+
+5. [Data Visualization](05_Data-Visualization.md) — Heat maps, treemaps, scatter plots, correlation matrices, yield curves, and volatility surfaces
+   - `PositionHeatMap`, `CorrelationMatrix`, `Treemap`, `ScatterPlot`, `YieldCurve`, `ForwardCurve`, `VolatilitySurface`, `VolSmileSkew`, `DendrogramCluster`
+
+6. [Custom Analytics and Scripting](06_Custom-Analytics-And-Scripting.md) — User-defined formula columns, custom chart indicators, screening/scanning, and backtesting
+   - `FormulaColumn`, `CustomIndicator`, `Scanner`, `BacktestFramework`, `EquityCurve`, `SharpeRatio`, `ProfitFactor`, `AlertIntegration`
+
+7. [Audit and Compliance Views](07_Audit-And-Compliance-Views.md) — Trade surveillance, pattern detection, communication monitoring, and regulatory compliance dashboards
+   - `SurveillanceDashboard`, `SpoofingDetection`, `WashTradeDetection`, `FrontRunningAlert`, `CommunicationMonitor`, `RestrictedList`, `WatchList`, `ComplianceCase`
+
+8. [Dashboard Design Principles](08_Dashboard-Design-Principles.md) — Layout hierarchy, refresh/latency targets, interactivity standards, and data quality indicators
+   - `LayoutHierarchy`, `RefreshRate`, `CrossFiltering`, `DrillDown`, `StaleDataWarning`, `ReconciliationStatus`, `ExportCapability`

--- a/docs/trading-desk/18-user-management-and-permissions/README.md
+++ b/docs/trading-desk/18-user-management-and-permissions/README.md
@@ -4,10 +4,23 @@ Covers user roles, personas, role-based access control, trader profiles, desk or
 
 ## Contents
 
-1. [User Roles and Personas](01_User-Roles-And-Personas.md)
-2. [Role-Based Access Control](02_Role-Based-Access-Control.md)
-3. [Trader Profiles and Desk Organization](03_Trader-Profiles-And-Desk-Organization.md)
-4. [Multi-Tenancy and User Session Management](04_Multi-Tenancy-And-User-Session-Management.md)
-5. [Audit Trails for User Actions](05_Audit-Trails-For-User-Actions.md)
-6. [Onboarding and Offboarding Workflows](06_Onboarding-And-Offboarding-Workflows.md)
-7. [Delegation, Proxy Trading, and Communication Tools](07_Delegation-Proxy-Trading-And-Communication-Tools.md)
+1. [User Roles and Personas](01_User-Roles-And-Personas.md) — Defines eight user personas (trader, PM, risk manager, compliance, ops, IT, management, quant) with permissions and workflows
+   - `Trader`, `PortfolioManager`, `RiskManager`, `ComplianceOfficer`, `OperationsStaff`, `ITSupport`, `QuantAnalyst`, `SeparationOfDuties`
+
+2. [Role-Based Access Control](02_Role-Based-Access-Control.md) — Four-dimensional RBAC: desk, instrument, function, and data entitlements with permission evaluation pipeline
+   - `desk.view`, `desk.trade`, `order.create`, `order.cancel_all`, `risk.kill_switch`, `PermissionEvaluationPipeline`, `FourEyesPrinciple`, `RestrictedList`, `DataEntitlement`
+
+3. [Trader Profiles and Desk Organization](03_Trader-Profiles-And-Desk-Organization.md) — Trader profile structure, order defaults hierarchy, venue/algo preferences, per-trader risk limits, and desk structure
+   - `TraderProfile`, `TradingDefaults`, `VenuePreferences`, `AlgoPreferences`, `PerTraderRiskLimits`, `TradingDesk`, `SmartOrderRouter`, `LimitEscalation`
+
+4. [Multi-Tenancy and User Session Management](04_Multi-Tenancy-And-User-Session-Management.md) — Multi-fund/client tenancy models, information barriers (Chinese walls), SSO, session timeouts, and device management
+   - `TenancyModel`, `InformationBarrier`, `WallCrossingProcedure`, `ClientSegregation`, `AllocationPolicy`, `SSO`, `SessionTimeout`, `ConcurrentSessionPolicy`, `DeviceManagement`
+
+5. [Audit Trails for User Actions](05_Audit-Trails-For-User-Actions.md) — Regulatory audit requirements, login/order/config change logging, WORM storage, and tamper-evident retrieval
+   - `LoginEvent`, `OrderEvent`, `ConfigChangeEvent`, `LimitChangeEvent`, `WORMStorage`, `AuditTrailRetrieval`, `AnomalyDetection`, `ImmutableRecord`
+
+6. [Onboarding and Offboarding Workflows](06_Onboarding-And-Offboarding-Workflows.md) — Multi-step new user provisioning, immediate/planned offboarding, and internal role transfer procedures
+   - `OnboardingWorkflow`, `IdentityProvisioning`, `RiskLimitConfiguration`, `ComplianceSetup`, `ImmediateOffboarding`, `PlannedOffboarding`, `RoleTransfer`, `LitigationHold`
+
+7. [Delegation, Proxy Trading, and Communication Tools](07_Delegation-Proxy-Trading-And-Communication-Tools.md) — Trading-on-behalf-of delegation, vacation coverage, escalation procedures, and Bloomberg/Symphony/Eikon integration
+   - `DelegationRecord`, `VacationCoverage`, `EscalationWorkflow`, `BloombergIBIntegration`, `SymphonyBot`, `EikonMessenger`, `SquawkBox`, `CommunicationArchival`


### PR DESCRIPTION
## Summary
- Adds inline descriptions and domain-specific key terms to the table of contents in all 18 trading desk documentation sections
- Improves navigability by giving readers immediate context about each sub-document's scope
- Lists relevant structs, protocols, and concepts (e.g., `ITCH`, `OHLCV`, `FeedHandler`, `RiskLimit`) alongside each link

## Test plan
- [x] Verify all markdown links remain valid
- [x] Confirm formatting renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)