### PR TITLE
chore: archive Kraken integration spec artifacts

### DIFF
--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/01-questions-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/01-questions-01.md
@@ -1,0 +1,36 @@
+---
+phase: 1
+iteration: 01
+generated: 2026-04-03
+---
+
+# Research Questions: Professional Trading Desk with Kraken Exchange Integration
+
+Source issue: Feature request — build a complete professional trading desk in pure Zig with Kraken exchange integration, zero external dependencies, everything from official specs/RFCs/academic papers.
+Feature slug: trading-desk-kraken-integration
+
+## Questions
+
+1. What Kraken REST and WebSocket API endpoints are documented for spot trading, and what are the exact authentication mechanisms (API key signing, nonce handling, HMAC construction), rate limit structures, and error response formats specified across `docs/kraken-exchange-documentation/`?
+
+2. What Kraken futures exchange API endpoints, WebSocket channels, and FIX protocol integration details are documented, and how do the futures API authentication, order types, and margin/collateral models differ from the spot exchange APIs?
+
+3. What order types, order lifecycle states, state transition rules, amendment/cancellation workflows, and parent-child order relationships are specified in `docs/trading-desk/02-order-management-system/`, and what validation and pre-trade checks are described?
+
+4. What real-time market data feed formats, normalization approaches, tick data storage strategies, order book reconstruction methods, and conflation techniques are detailed in `docs/trading-desk/01-market-data-systems/`?
+
+5. What risk management calculations (VaR, Greeks, stress testing), pre-trade risk controls, risk limit structures, and real-time risk monitoring architectures are specified in `docs/trading-desk/05-risk-management/`?
+
+6. What connectivity protocols, message formats, and session management patterns are documented in `docs/trading-desk/06-connectivity-and-protocols/`, particularly for FIX protocol, WebSocket lifecycle, and gateway/adapter architecture?
+
+7. What low-latency architecture patterns, event-driven designs, high-availability strategies, capacity planning approaches, and security requirements are described in `docs/trading-desk/07-infrastructure-and-architecture/`?
+
+8. What position tracking models, multi-currency position handling, P&L calculation methods, reconciliation workflows, and start-of-day/end-of-day position procedures are specified across `docs/trading-desk/04-position-management/` and `docs/trading-desk/15-operational-workflows/`?
+
+9. What execution algorithm types (TWAP, VWAP, iceberg, etc.), smart order routing logic, execution quality measurement methods, and market microstructure considerations are documented in `docs/trading-desk/03-execution-and-algorithms/`?
+
+10. What post-trade processing workflows (trade confirmation, clearing, settlement, allocation, reconciliation), audit trail requirements, and compliance/regulatory reporting obligations are specified across `docs/trading-desk/13-post-trade-processing/` and `docs/trading-desk/14-compliance-and-regulatory/`?
+
+11. What trading UI components (order tickets, blotters, market data displays, charting), workspace layouts, keyboard interaction patterns, and dashboard/analytics views are documented in `docs/trading-desk/16-trading-ui-components/` and `docs/trading-desk/17-dashboard-and-analytics/`?
+
+12. What cryptocurrency-specific trading features — including derivatives (futures, options), margin models, funding rates, liquidation mechanics, and settlement processes — are documented across `docs/trading-desk/12-futures-and-listed-derivatives/` and `docs/trading-desk/11-options-trading/` as they relate to the Kraken exchange integration?

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/02-research-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/02-research-01.md
@@ -1,0 +1,562 @@
+---
+phase: 2
+iteration: 01
+generated: 2026-04-03
+---
+
+# Research: Professional Trading Desk with Kraken Exchange Integration
+
+Questions source: .claude/specs/trading-desk-kraken-integration/01-questions-01.md
+
+## 1. Kraken Spot REST and WebSocket API Endpoints, Authentication, Rate Limits, and Error Formats
+
+### REST API Authentication
+- Private endpoints require four parameters: `API-Key` header, `API-Sign` header, `nonce` (always-increasing 64-bit integer), and optional `otp` for 2FA (`docs/kraken-exchange-documentation/01-guides/04-spot-exchange/03-rest/01_Authentication.md:11-12`)
+- API-Sign formula: `HMAC-SHA512(URI_path + SHA256(nonce + POST_data), base64_decode(api_secret))` (`01_Authentication.md:22-24`)
+- URI path portion starts with `/0/private` (`01_Authentication.md:22`)
+- Nonce must be always-increasing unsigned 64-bit integer; common approach is UNIX timestamps in milliseconds (`01_Authentication.md:41-45`)
+- Too many invalid nonces (`EAPI:Invalid nonce`) can result in temporary bans (`01_Authentication.md:43`)
+- For shared API keys, nonces must be coordinated through centralized store (`01_Authentication.md:45`)
+
+### REST API Endpoints
+- Trading: `POST /0/private/AddOrder` supports order types: market, limit, stop-loss, take-profit, stop-loss-limit, take-profit-limit, trailing-stop, trailing-stop-limit, settle-position (`docs/kraken-exchange-documentation/03-spot-rest/06-trading/02_Add-Order.md:24`)
+- Maximum open orders: 225 for standard accounts (`02_Add-Order.md:99`)
+- Market data endpoints: `/0/public/Assets`, `/0/public/AssetPairs`, `/0/public/Depth` (L2), `/0/public/OHLC`, `/0/public/Spread`, `/0/public/Trades`, `/0/public/Ticker`, `/0/public/SystemStatus` (`docs/kraken-exchange-documentation/03-spot-rest/04-market-data/README.md`)
+
+### REST API Rate Limits
+- Call counter mechanism: starts at zero, ledger/trade-history calls increment by 2, all others by 1 (`docs/kraken-exchange-documentation/01-guides/04-spot-exchange/03-rest/04_Rate-Limits.md:7-15`)
+- Tier limits: Starter max 15 (decay -0.33/sec), Intermediate max 20 (decay -0.5/sec), Pro max 20 (decay -1/sec) (`04_Rate-Limits.md:9-13`)
+- AddOrder and CancelOrder have separate rate limiting mechanisms (`04_Rate-Limits.md:9`)
+- Error responses: `EAPI:Rate limit exceeded` for counter exceeded, `EService: Throttled: [UNIX timestamp]` for excessive concurrent requests (`04_Rate-Limits.md:25-30`)
+
+### REST API Error Response Format
+- JSON with `result` and `error` keys for success, or solely `error` for failures (`docs/kraken-exchange-documentation/01-guides/04-spot-exchange/03-rest/03_Introduction.md:24-25`)
+- Error pattern: `<severity><category>: <description>` where severity is `E` (error) or `W` (warning), categories include General, Auth, API, Query, Order, Trade, Funding, Service (`03_Introduction.md:49-57`)
+- Key error codes from AddOrder: `EGeneral:Invalid arguments`, `EGeneral:Permission denied`, `EOrder:Insufficient funds`, `EOrder:Minimum order volume not met`, `EOrder:Rate limit exceeded`, `EOrder:Post only order`, `EAPI:Invalid nonce` (`03_Introduction.md:81-95`)
+
+### WebSocket API
+- Endpoints: v2 public `wss://ws.kraken.com/v2`, v2 private `wss://ws-auth.kraken.com/v2`, v1 public `wss://ws.kraken.com`, v1 private `wss://ws-auth.kraken.com` (`docs/kraken-exchange-documentation/01-guides/04-spot-exchange/04-websockets/04_Introduction.md:7-14`)
+- Authentication: obtain token via REST `GetWebSocketsToken` endpoint; token valid 15 minutes (`01_Authentication.md:9-11,31`)
+- WebSocket v2 improvements: FIX-like design, readable pair symbols (e.g., "BTC/USD"), RFC3339 timestamps, prices as number types, optional `req_id` for response matching (`04_Introduction.md:22-43`)
+- v2 add_order method supports: market, limit, iceberg, stop-loss, stop-loss-limit, take-profit, take-profit-limit, trailing-stop, trailing-stop-limit, settle-position (`docs/kraken-exchange-documentation/06-websocket-v2/04-user-trading/01_Add-Order.md:125-137`)
+- Connection: TLS with SNI mandatory, ~1 minute timeout for inactive connections, Cloudflare limits ~150 reconnects per 10-minute rolling window per IP (`04_Introduction.md:56-67`)
+
+### FIX API
+- Two-layer authentication via `SenderCompID` (Tag 49); separate API keys for Spot and Futures with `DRV` suffix for derivatives (`docs/kraken-exchange-documentation/01-guides/04-spot-exchange/01-fix/01_Authentication.md:9-15`)
+- FIX password: `base64(HMAC-SHA512(base64_decode(api_secret), SHA256(message_input + nonce)))` (`01_Authentication.md:26-34`)
+- Message-input: concatenation of `35=A`, `34=MsgSeqNum`, `49=SENDERCOMPID`, `56=TARGETCOMPID`, `553=API_KEY` with SOH delimiter (`docs/kraken-exchange-documentation/04-spot-fix/02_Logon.md:38-44`)
+- Nonce must be within 5 seconds of server time, strictly increasing (`02_Logon.md:47-51`)
+- FIX NewOrderSingle (MsgType D) supports: market, limit, stop-loss, stop-loss-limit, take-profit, take-profit-limit, trailing-stop, trailing-stop-limit (`docs/kraken-exchange-documentation/04-spot-fix/08_New-Order-Single.md:13-22`)
+- ExecutionReport ExecType values: `0`=New, `4`=Canceled, `5`=Replace, `A`=Pending New, `C`=Expired, `D`=Restated, `F`=Trade, `I`=Order Status (`docs/kraken-exchange-documentation/04-spot-fix/01_Execution-Report.md:11-51`)
+
+## 2. Kraken Futures Exchange API Endpoints, WebSocket Channels, and FIX Protocol Differences
+
+### Futures REST API
+- Base URLs: REST `https://futures.kraken.com/derivatives/api/v3/`, History `https://futures.kraken.com/api/history/v2/`, Charts `https://futures.kraken.com/api/charts/v1/`, WebSocket `wss://futures.kraken.com/ws/v1`, Demo `https://demo-futures.kraken.com/` (`docs/kraken-exchange-documentation/01-guides/03-futures-exchange/01_Introduction.md:78-86`)
+- 13 endpoint categories: Account, Assignment Program, Charts, Fee Schedules, General, History, Instruments, Market Data, Multi Collateral, Order Management, RFQ, Settings, Transfers (`docs/kraken-exchange-documentation/07-futures-rest/README.md`)
+- Send order: `POST /sendorder` supports order types: `lmt`, `post`, `mkt`, `stp`, `take_profit`, `ioc`, `trailing_stop`, `fok` (`docs/kraken-exchange-documentation/07-futures-rest/10-order-management/10_Send-Order.md:38-39`)
+- Dead man's switch: `POST /cancelallordersafter` recommended every 15-20s with 60s timeout (`10-order-management/README.md`)
+- Batch orders: `POST /batchorder` with cost of 9 + batch size (`docs/kraken-exchange-documentation/01-guides/03-futures-exchange/02_Rate-Limits.md:36`)
+
+### Futures Authentication Differences
+- Headers: `APIKey`, `Authent` (signature), `Nonce` (optional but recommended) (`docs/kraken-exchange-documentation/01-guides/03-futures-exchange/03_Rest.md:7-15`)
+- Authent formula: `HMAC-SHA512(base64_decode(api_secret), SHA256(postData + nonce + endpoint_path))` (`03_Rest.md:26-35`)
+- PostData formatted as `&`-concatenated parameters; endpoint path is URL extension (e.g., `/api/v3/orderbook`) (`03_Rest.md:19-23`)
+- As of Feb 2024, API hashes full URL-encoded parameters; backward compatible until Oct 2025 (`03_Rest.md:37-39`)
+
+### Futures Rate Limits
+- 500 cost units per 10 seconds for `/derivatives` endpoints; public endpoints cost 0 (`docs/kraken-exchange-documentation/01-guides/03-futures-exchange/02_Rate-Limits.md:7-8`)
+- Key costs: sendorder=10, editorder=10, cancelorder=10, batchorder=9+batch_size, accounts=2, openpositions=2, cancelallorders=25, cancelallordersafter=25 (`02_Rate-Limits.md:10-35`)
+- History endpoints: 100 token pool, replenishes at 100 per 10 minutes (`02_Rate-Limits.md:40-54`)
+- WebSocket: 100 connections max, 100 requests/second (`02_Rate-Limits.md:66-74`)
+
+### Futures WebSocket
+- URL: `wss://futures.kraken.com/ws/v1`; must ping at least every 60 seconds (`docs/kraken-exchange-documentation/01-guides/03-futures-exchange/04_Websockets.md:34-38`)
+- Authentication via signed challenge: `base64(HMAC-SHA512(base64_decode(api_secret), SHA256(challenge)))` (`04_Websockets.md:15-20`)
+- 13 channels: Account Log, Balances, Book, Challenge, Fills, Heartbeat, Notifications, Open Orders, Open Orders Verbose, Open Positions, Ticker Lite, Ticker, Trade (`docs/kraken-exchange-documentation/08-futures-websocket/README.md`)
+
+### Futures Margin and Collateral
+- Two account types: Cash Account and Multi-Collateral Margin Account (`docs/kraken-exchange-documentation/07-futures-rest/01-account/01_Get-Accounts.md:50-76`)
+- Multi-collateral fields: initialMargin, maintenanceMargin, balanceValue, portfolioValue, collateralValue, availableMargin, marginEquity (`01_Get-Accounts.md:50-76`)
+- Margin equity formula: `[Balance Value * (1-Haircut)] + (Total Unrealised Profit/Loss as Margin)` (`01_Get-Accounts.md:66`)
+- Leverage preferences: `GET/PUT /leveragepreferences` for isolated vs cross margin with max leverage (`docs/kraken-exchange-documentation/07-futures-rest/09-multi-collateral/01_Get-Leverage-Setting.md:41-46`)
+- PnL currency preferences: `GET/PUT /pnlpreferences` (`09-multi-collateral/02_Get-Pnl-Currency-Preference.md`)
+- Portfolio margin parameters available in demo: crossAssetNettingFactor, extremePriceShockMultiplier, volShockMultiplicationFactor, priceShockLevels, optionsUserLimits (`docs/kraken-exchange-documentation/07-futures-rest/01-account/03_Get-Portfolio-Margining-Parameters.md:45-59`)
+
+### Key Spot vs Futures Differences
+- Separate trading engines with distinct protocols, onboarding, authentication, rate limits, error handling (`docs/kraken-exchange-documentation/01-guides/01_Kraken-Apis.md:37-39`)
+- Symbol format: Spot uses pairs like "BTC/USD"; Futures uses prefixed symbols like `fi_xbtusd`, `fi_xbtusd_180615` (`01_Introduction.md:33-42`)
+- Datetime: Futures use ISO8601 `yyyy-mm-ddTHH:MM:SS.sssZ` (`01_Introduction.md:28-30`)
+
+## 3. Order Types, Lifecycle States, State Transitions, Amendment/Cancellation Workflows, and Parent-Child Relationships
+
+### Order Types
+- Basic: Market (FIX Tag 40: `1`), Limit (`2`), Stop (`3`), Stop-Limit (`4`), Trailing Stop (`P` FIX 5.0) with PegOffsetValue (tag 211) and PegOffsetType (tag 836) (`docs/trading-desk/02-order-management-system/01_Order-Types.md:5-71`)
+- Time-in-Force (Tag 59): Day (`0`), GTC (`1`), IOC (`3`), FOK (`4`), GTD (`6`), At-the-Open (`2`), At-the-Close (`7`), Good-for-Auction (`A`) (`01_Order-Types.md:77-84`)
+- Auction: MOO (OrdType=1, TIF=2), LOO (OrdType=2, TIF=2), MOC (OrdType=1, TIF=7, NYSE cutoff 3:50 PM ET), LOC (OrdType=2, TIF=7) (`01_Order-Types.md:93-127`)
+- Hidden: Iceberg/Reserve using MaxFloor (tag 111), Hidden/Non-Displayed using DisplayMethod (tag 1084)=`4` (`01_Order-Types.md:131-154`)
+- Pegged (OrdType `P`): Primary Peg, Market Peg, Midpoint Peg, D-Peg (IEX); uses PegPriceType (tag 1094) (`01_Order-Types.md:156-186`)
+- Special: All-or-None (ExecInst tag 18=`G`), Minimum Quantity (MinQty tag 110), Not Held (ExecInst=`1`) (`01_Order-Types.md:190-215`)
+
+### Order Lifecycle States (OrdStatus, Tag 39)
+- States: PendingNew (`A`), New (`0`), PartiallyFilled (`1`), Filled (`2`), DoneForDay (`3`), Cancelled (`4`), Replaced (`5`), PendingCancel (`6`), Rejected (`8`), Suspended (`9`), PendingReplace (`E`), Expired (`C`) (`docs/trading-desk/02-order-management-system/02_Order-Lifecycle-And-State-Machine.md:63-74`)
+- Terminal states: Filled, Cancelled, Rejected, Expired (`02_Order-Lifecycle-And-State-Machine.md:66-74`)
+
+### State Transitions
+- PendingNew -> New, Rejected; New -> PartiallyFilled, Filled, Cancelled, Replaced, Expired, Suspended, DoneForDay, PendingCancel, PendingReplace (`02_Order-Lifecycle-And-State-Machine.md:78-87`)
+- Critical race conditions: fill-before-cancel (process fill first), fill-before-replace (process fill first, replace applies to leaves), unsolicited cancel (venue cancels without user request) (`02_Order-Lifecycle-And-State-Machine.md:89-100`)
+
+### Internal OMS States (Beyond FIX)
+- Staged, Validating, RoutePending, SentToAlgo, AlgoWorking, ManualReview, CancelPending (internal) (`02_Order-Lifecycle-And-State-Machine.md:103-114`)
+- Order versioning: each amendment creates new version with timestamp, user, previous/new values, ClOrdID/OrigClOrdID linkage (`02_Order-Lifecycle-And-State-Machine.md:116-131`)
+
+### Amendment and Cancellation Workflows
+- Cancel Request (MsgType `F`): requires OrigClOrdID (41), ClOrdID (11), Side (54), Symbol (55), TransactTime (60) (`docs/trading-desk/02-order-management-system/05_Amendments-Cancellations-And-Parent-Child-Orders.md:5-23`)
+- Cancel Reject (MsgType `9`) with CxlRejReason (102): `0` (Too late), `1` (Unknown order), `2` (Broker option), `3` (Already pending), `99` (Other) (`05_Amendments.md:5-23`)
+- Cancel/Replace (MsgType `G`): atomic cancel-and-submit; time priority retention depends on venue and change nature (`05_Amendments.md:25-46`)
+- Mass Cancel: iterative, venue mass cancel, or kill switch (SEC 15c3-5) (`05_Amendments.md:48-62`)
+- Cancel-on-Disconnect (FIX Tag 8013): session-level, cascades to child orders for algos (`05_Amendments.md:64-77`)
+
+### Parent-Child Order Relationships
+- Algo decomposition: parent order spawned into child orders; invariants: sum(child qty) <= parent qty, parent CumQty = sum(child CumQty), parent AvgPx = qty-weighted avg of child fills (`05_Amendments.md:83-104`)
+- FIX linkage: ClOrdLinkID (583), ParentOrderID (custom), ChildOrderCount (custom) (`05_Amendments.md:83-104`)
+- Bracket Orders: primary + take-profit + stop-loss; take-profit and stop-loss form OCO pair (`05_Amendments.md:114-124`)
+- OCO: ContingencyType (1385)=`1`, shared ClOrdLinkID (583); partial fill handling configurable (`05_Amendments.md:126-138`)
+- Contingent Orders: if-touched, if-done, if-filled, conditional on market data; OMS maintains contingency evaluation engine (`05_Amendments.md:140-155`)
+
+## 4. Real-Time Market Data Feeds, Normalization, Tick Data Storage, Order Book Reconstruction, and Conflation
+
+### Feed Formats
+- Level 1 (Top of Book): Best Bid/Ask Price+Size, Last Trade Price/Size/Time, Cumulative Volume, VWAP, Open/High/Low/Close, Net Change (`docs/trading-desk/01-market-data-systems/01_Overview-And-Real-Time-Market-Data-Feeds.md:17-48`)
+- NBBO vs BBO: BBO is single-venue best bid/ask; NBBO is cross-all-protected-US-exchanges under Reg NMS (`01_Overview.md:41-44`)
+- Level 2 Market-by-Price (MBP): aggregated orders at each price level; typical depth 5/10/20 levels (`01_Overview.md:54-67`)
+- Level 2 Market-by-Order (MBO): individual order-level detail with unique order ID; significantly higher bandwidth; enables queue position estimation, iceberg detection (`01_Overview.md:69-93`)
+- MBO exchanges: NASDAQ TotalView-ITCH, NYSE Integrated Feed, CME MDP 3.0 MBO, LSE Full Order Book, Eurex EOBI, ASX ITCH, TMX Quantum Feed (`01_Overview.md:69-93`)
+
+### Data Normalization
+- Symbology mapping across: exchange-native (NYSE tickers, CME Globex symbols), ISIN, CUSIP, SEDOL, FIGI, MIC codes (`docs/trading-desk/01-market-data-systems/03_Data-Normalization-And-Market-Data-Protocols.md:1-49`)
+- Price scaling (integer prices with implicit decimal), quantity normalization (lot sizes), currency normalization, timestamp normalization (to UTC nanoseconds since epoch), trade condition mapping, venue identification (to ISO 10383 MIC) (`03_Data-Normalization.md:50-59`)
+- CME month codes: F=Jan, G=Feb, H=Mar, J=Apr, K=May, M=Jun, N=Jul, Q=Aug, U=Sep, V=Oct, X=Nov, Z=Dec (`03_Data-Normalization.md:9-16`)
+
+### Market Data Protocols
+- FIX: tag-value ASCII, messages 35=W (Snapshot), 35=X (Incremental), 35=V (Request) (`03_Data-Normalization.md:67-75`)
+- FAST: binary FIX compression using presence maps, stop-bit encoding, delta encoding; 50-90% bandwidth reduction (`03_Data-Normalization.md:73-86`)
+- SBE: fixed-layout binary for deterministic zero-copy parsing; used by CME MDP 3.0, Eurex T7 (`docs/trading-desk/06-connectivity-and-protocols/03_Market-Data-Protocols.md:14-20`)
+- ITCH (NASDAQ): unidirectional binary, message types A/F (Add), E/C (Execute), X (Cancel), D (Delete), U (Replace), P (Trade); 100,000+ msgs/sec peak (`03_Data-Normalization.md:90-112`)
+- OUCH: order-entry companion to ITCH (`03_Data-Normalization.md:115-117`)
+- PITCH (Cboe): binary, similar to ITCH; multicast UDP with TCP gap-fill (`03_Data-Normalization.md:119-126`)
+- CME MDP 3.0: SBE over multicast UDP; 10-level MBP + MBO; peak 25M+ msgs/sec (`03_Data-Normalization.md:128-137`)
+
+### Transport
+- Multicast UDP dominant; dual-line (A/B) redundancy with line arbitration and sequence-number deduplication (`03_Data-Normalization.md:159-167`)
+- Kernel bypass: DPDK, Solarflare OpenOnload, FPGA NICs reduce NIC-to-app latency from ~10us to ~1-2us or sub-microsecond (`03_Data-Normalization.md:159-167`)
+- TCP recovery: retransmission service, snapshot channels, re-spin for late joiners (`03_Data-Normalization.md:171-176`)
+
+### Tick Data Storage
+- Volume: single US exchange 5-10B msgs/day; all US venues >100B/day; OPRA 100B+ (`docs/trading-desk/01-market-data-systems/04_Tick-Data-Storage-And-Conflation.md:4-11`)
+- Specialized: KDB+/q (industry standard, column-oriented, in-memory + memory-mapped), OneTick (`04_Tick-Data-Storage.md:15-22`)
+- General-purpose: TimescaleDB (PostgreSQL extension), QuestDB (column-oriented, high-throughput), ClickHouse (exceptional compression), DuckDB (in-process OLAP over Parquet) (`04_Tick-Data-Storage.md:24-32`)
+- File-based: Apache Parquet (de facto for analytical storage, column-oriented, Snappy/Zstd compression), Arrow/Feather, HDF5, flat binary (`04_Tick-Data-Storage.md:34-41`)
+- KDB+ architecture: Tickerplant -> RDB (in-memory) + HDB (date-partitioned on disk) (`04_Tick-Data-Storage.md:43-51`)
+
+### Order Book Reconstruction
+- From ITCH: maintain two-sided price-level hierarchy; Add Order -> insert at price level; Replace -> modify; Execute -> reduce size; Cancel/Delete -> remove (`03_Data-Normalization.md:90-112`)
+- Sequence numbers enable gap detection and recovery; full state reconstructable from SOD snapshot + incremental messages (`03_Data-Normalization.md:90-112`)
+
+### Bar Aggregation and Conflation
+- OHLCV bars at intervals: 1s, 5s, 1m, 5m, 15m, 30m, 1h, daily (`04_Tick-Data-Storage.md:57-67`)
+- Alternative bars: volume bars, dollar bars, tick bars, renko bars, range bars (`04_Tick-Data-Storage.md:69-77`)
+- VWAP: `Sum(Price_i * Volume_i) / Sum(Volume_i)` with trade condition filtering; continuous vs interval vs anchored (`04_Tick-Data-Storage.md:79-92`)
+
+## 5. Risk Management Calculations, Pre-Trade Controls, Risk Limits, and Real-Time Monitoring
+
+### VaR Calculations
+- Historical VaR: N days of returns applied to current portfolio; 250 days at 99% = 2nd worst loss (`docs/trading-desk/05-risk-management/01_Market-Risk.md:18-40`)
+- Parametric VaR: `VaR = z_alpha * sigma_portfolio * sqrt(T)` where z_alpha = 1.645 (95%) or 2.326 (99%) (`01_Market-Risk.md:42-73`)
+- Monte Carlo VaR: 10,000-100,000 scenarios using calibrated stochastic processes with Cholesky decomposition for correlations (`01_Market-Risk.md:75-100`)
+- Expected Shortfall (CVaR): `ES_alpha = E[Loss | Loss > VaR_alpha]`; coherent (satisfies subadditivity); Basel III FRTB replaced VaR with ES (`01_Market-Risk.md:102-124`)
+
+### Greeks
+- Delta: `Call Delta = N(d1)`, `Put Delta = N(d1) - 1`; portfolio delta = sum of position deltas (`docs/trading-desk/05-risk-management/05_Real-Time-Risk-Calculations-Options-Greeks.md:7-35`)
+- Gamma: `N'(d1) / (S * sigma * sqrt(T))`; dollar gamma for 1% move: `0.5 * Gamma * S^2 * Qty * Multiplier / 100` (`05_Greeks.md:39-62`)
+- Vega: `S * N'(d1) * sqrt(T) * exp(-q*T)`; vega matrix tracked by tenor and strike (`05_Greeks.md:64-92`)
+- Theta: daily time decay; portfolio theta = sum of position thetas (`05_Greeks.md:94-113`)
+- Rho: `Call Rho = K * T * exp(-r*T) * N(d2)`; significant for long-dated options (`05_Greeks.md:115-127`)
+
+### Fixed Income Risk
+- DV01: change in price for 1bp yield shift; `DV01 = ModifiedDuration * Price * 0.0001` (`docs/trading-desk/05-risk-management/06_Real-Time-Risk-Calculations-Fixed-Income-And-Architecture.md:3-25`)
+- Key Rate DV01s at standard tenors: 3M, 6M, 1Y, 2Y, 3Y, 5Y, 7Y, 10Y, 15Y, 20Y, 30Y (`06_Fixed-Income.md:27-43`)
+- CS01 (Credit Spread 01): `SpreadDuration * Price * 0.0001 * FaceValue` (`06_Fixed-Income.md:45-54`)
+- Convexity: `dP/P = -ModifiedDuration * dy + 0.5 * Convexity * dy^2` (`06_Fixed-Income.md:56-67`)
+
+### Pre-Trade Risk Controls
+- Sequential pipeline: Order Validation -> Price Reasonability -> Size Limits -> Position Limits -> Credit/Margin Check -> Concentration Check -> Message Rate Throttle -> Duplicate Check (`docs/trading-desk/05-risk-management/04_Pre-Trade-Risk-Controls.md:7-36`)
+- Size limits: max shares/order, max notional/order ($5M), max notional/day ($100M/trader), max % ADV (5%), max orders/sec (100/session) (`04_Pre-Trade.md:38-46`)
+- Price checks: equity reject if >5% from NBBO mid or >10% from last trade; options reject if >50% from theoretical or implied vol >200% (`04_Pre-Trade.md:48-64`)
+- Message rate throttling: exchange limits 50-300 msgs/sec (equity), internal limits 10-50 orders/sec per trader; OTR monitoring if >100:1 (`04_Pre-Trade.md:96-120`)
+
+### Risk Limits
+- Hierarchy: Board (VaR $50M, Stress $200M) -> Division (VaR $30M) -> Desk (VaR $10M, Delta ±$500M, Gamma ±$5M, Vega ±$3M, Theta -$200K) -> Trader (VaR $2M, Max Single Name $50M, Stop-loss $500K/day) -> Strategy (VaR $3M) (`docs/trading-desk/05-risk-management/07_Risk-Limits-And-Breaches.md:14-42`)
+- Utilization zones: Green 0-75%, Amber 75-90%, Red 90-100%, Breach >100% (`07_Risk-Limits.md:44-57`)
+- Breach escalation: T+0 risk manager, T+1 desk head, T+2 CRO, T+5 board risk committee (`07_Risk-Limits.md:59-87`)
+- Stop-loss limits: daily, weekly, monthly, YTD; trigger halts risk-increasing activity (`07_Risk-Limits.md:119-134`)
+
+### Stress Testing
+- Historical scenarios: Black Monday (-22%), GFC (-57%), COVID (-34%, VIX >80), 2022 Rate Shock (`docs/trading-desk/05-risk-management/08_Stress-Testing-And-Scenario-Analysis.md:3-42`)
+- Hypothetical scenarios: Sudden Rate Hike, China Devaluation, Cybersecurity Attack (`08_Stress-Testing.md:44-74`)
+- Reverse stress testing: search for risk factor combinations producing target loss via optimization (`08_Stress-Testing.md:76-99`)
+- Sensitivity (bump-and-reprice): spot moves -20% to +20%, vol moves -10pts to +10pts producing P&L matrix (`08_Stress-Testing.md:113-129`)
+
+### Real-Time Risk Monitoring Architecture
+- Pipeline: Market Data -> Tick Plant -> [Equity Pricer, Rates Engine, Vol Surface, FX Engine] -> Risk Aggregation -> [Greeks Server, VaR Engine, Stress Engine] -> Dashboard/Alerts (`06_Fixed-Income.md:90-120`)
+- Latency targets: Greeks <100ms after tick, Position P&L <50ms, Portfolio VaR 1-5 min refresh, Stress 1-15 min refresh (`06_Fixed-Income.md:114-118`)
+
+### Risk Attribution
+- Factor model: `Return_i = alpha_i + sum(Beta_ik * Factor_k) + epsilon_i` with Barra style/industry/country/currency factors (`docs/trading-desk/05-risk-management/10_Risk-Attribution-Factor-Models.md:1-57`)
+- Marginal VaR: `dVaR/dw_i`; Component VaR: `w_i * Marginal_VaR_i` (sums to total VaR); Incremental VaR: full non-linear impact of adding/removing position (`docs/trading-desk/05-risk-management/11_Risk-Attribution-Marginal-And-Component.md:1-54`)
+
+### Regulatory Risk
+- Basel III FRTB: replaced VaR with ES at 97.5%; liquidity horizons 10-120 days by asset class; P&L Attribution Test (Spearman >0.7 AND KL divergence <0.09) (`docs/trading-desk/05-risk-management/09_Regulatory-Risk-Requirements.md:34-87`)
+- ISDA SIMM for initial margin: `IM = sqrt(sum_rc[IM_rc^2] + 2*sum[psi*IM_rc1*IM_rc2])` with risk weights per factor (`09_Regulatory.md:112-143`)
+
+## 6. Connectivity Protocols, Message Formats, and Session Management
+
+### FIX Protocol
+- Dominant versions: FIX 4.2 and 4.4 (entrenchment); new exchanges mandate FIX 5.0 SP2 (`docs/trading-desk/06-connectivity-and-protocols/01_FIX-Protocol.md:7-20`)
+- Session layer (FIXT 1.1): Logon (`A`), Logout (`5`), Heartbeat (`0`, typically 30s), TestRequest (`1`), ResendRequest (`2`), SequenceReset (`4`), Reject (`3`) (`01_FIX-Protocol.md:24-52`)
+- Session ID tuple: SenderCompID (49) + TargetCompID (56) + optional SenderSubID (50), TargetSubID (57), SenderLocationID (142) (`01_FIX-Protocol.md:24-52`)
+- Sequence numbers: independent per side, persisted across disconnections, gap detection triggers ResendRequest, PossDupFlag (43) for retransmissions (`01_FIX-Protocol.md:46-52`)
+- Order flow: NewOrderSingle (`D`), CancelReplace (`G`), CancelRequest (`F`), ExecutionReport (`8`), CancelReject (`9`), MultiLeg (`AB`), List (`E`), Cross (`s`) (`01_FIX-Protocol.md:60-71`)
+- Wire format: `8=FIX.4.4|9=BodyLen|35=MsgType|...` with SOH (0x01) delimiter, tag 10 checksum always last (`01_FIX-Protocol.md:128-142`)
+- FIXP: binary session protocol for low-latency, supports ordered and unordered delivery (`01_FIX-Protocol.md:144-150`)
+
+### FIX Engines
+- Open source: QuickFIX (C++), QuickFIX/J (Java), QuickFIX/N (C#/.NET), QuickFIX/Go (`docs/trading-desk/06-connectivity-and-protocols/02_FIX-Engines-And-Session-Management.md:5-16`)
+- Commercial: LSEG FIX Engine, B2BITS FIX Antenna, Chronicle FIX (ultra-low-latency), Rapid Addition RA-FIX (FPGA), TransFIX (.NET-native) (`02_FIX-Engines.md:18-28`)
+- Session lifecycle: TCP connect -> Logon exchange -> Sequence sync (ResendRequest if gap) -> Steady state (heartbeats) -> Disconnection handling (TestRequest) -> Logout (`02_FIX-Engines.md:63-70`)
+
+### Gateway and Adapter Architecture
+- Central abstraction: Internal Trading Core <-> Internal Protocol (Aeron/ZeroMQ/gRPC) <-> Per-venue gateways (NYSE Pillar, Nasdaq OUCH/ITCH, CME iLink3, generic FIX) (`docs/trading-desk/06-connectivity-and-protocols/11_Gateway-And-Adapter-Architecture.md:4-25`)
+- Gateway responsibilities: protocol translation, session management, symbol mapping, order ID mapping, rate limiting, throttling/queuing, failover, normalization, logging (nanosecond timestamps), enrichment (`11_Gateway.md:28-39`)
+- Feed handler architecture: NIC (kernel bypass) -> Line Arbitrator (A/B dedup) -> Protocol Decoder (ITCH/SBE/FAST/PITCH) -> Book Builder/Cache -> Internal Distribution (`11_Gateway.md:77-113`)
+- Feed handler targets: wire-to-internal <5us (co-located), >10M msgs/sec, book update <1us, zero GC pauses (`11_Gateway.md:115-120`)
+
+### Messaging Middleware
+- Solace PubSub+: sub-100us latency in appliance mode, prevalent on sell-side (`docs/trading-desk/06-connectivity-and-protocols/05_Message-Queuing-And-Middleware.md:7-14`)
+- Aeron: single-digit microsecond latency, reliable UDP, Raft-based cluster for replicated state machines; .NET wrapper available (`05_Middleware.md:45-53`)
+- Kafka: NOT for low-latency order routing; used for trade capture, audit logging, event sourcing, analytics pipelines (`05_Middleware.md:24-35`)
+- ZeroMQ: brokerless, microsecond latency, PUB/SUB/REQ/REP/PUSH/PULL patterns (`05_Middleware.md:37-43`)
+
+### Network Connectivity
+- Co-location: NYSE=Mahwah NJ, Nasdaq=Carteret NJ (Equinix NY5), CME=Aurora IL, LSE=Basildon UK, Eurex=Frankfurt (`docs/trading-desk/06-connectivity-and-protocols/04_Network-Connectivity.md:26-43`)
+- Microwave links: ~300,000 km/s (vs fiber ~200,000 km/s); key routes Carteret-Mahwah, Carteret-Aurora, Basildon-Frankfurt (`04_Network.md:45-61`)
+
+### Drop Copy and Trade Reporting
+- Drop copy: real-time read-only FIX session for all execution reports; used by middle office for independent risk/P&L calculation (`docs/trading-desk/06-connectivity-and-protocols/07_Drop-Copy-And-Trade-Reporting.md:3-19`)
+- Trade reporting: TRACE (fixed income), ORF (OTC equity), APA/ARM (MiFID II), CAT (US equities/options lifecycle) (`07_Drop-Copy.md:21-37`)
+- Protocols: FpML (OTC derivatives XML), FIX TradeCaptureReport, ISO 20022, DTCC CTM/Omgeo (`07_Drop-Copy.md:21-37`)
+
+## 7. Low-Latency Architecture Patterns, Event-Driven Designs, High-Availability, Capacity Planning, and Security
+
+### Low-Latency Architecture
+- Kernel bypass: Solarflare/Xilinx OpenOnload (2-5us vs 20-50us kernel), DPDK (poll-mode drivers), Mellanox VMA, io_uring, XDP, RDMA (`docs/trading-desk/07-infrastructure-and-architecture/01_Low-Latency-Architecture-And-Event-Driven-Architecture.md:1-34`)
+- CPU optimization: busy polling (100% CPU), CPU pinning (`sched_setaffinity`/`taskset`), `isolcpus` kernel parameter, NUMA awareness (avoid 50-100ns cross-socket), IRQ affinity (`01_Low-Latency.md:35-41`)
+- Lock-free structures: LMAX Disruptor (ring buffer), SPSC/MPSC queues, lock-free hash maps, atomic counters (`01_Low-Latency.md:43-62`)
+- Memory optimization: huge pages (2MB/1GB), pre-allocation, object pooling, cache-line alignment (64-byte), short-string optimization (`01_Low-Latency.md:80-92`)
+- GC mitigation: .NET `GC.TryStartNoGCRegion()`, server GC, pinned arrays; Java Azul Zing C4, ZGC, Shenandoah, or off-heap (`01_Low-Latency.md:80-92`)
+- FPGA acceleration for protocol parsing, risk checks, order generation (`01_Low-Latency.md:80-92`)
+- Latency measurement: hardware NIC timestamps (nanosecond), percentile reporting p50/p99/p99.9/p99.99 (`01_Low-Latency.md:94-102`)
+
+### Latency Budget (Co-Located System)
+- Total tick-to-trade: ~20-30us aggressive; NIC-to-app 1-3us, decode 0.5-2us, book update 0.1-0.5us, strategy 1-10us, risk check 1-5us, order encode 0.5-2us, app-to-NIC 1-3us, wire 0.1-0.5us (`docs/trading-desk/07-infrastructure-and-architecture/03_Capacity-Planning-And-Database-Considerations.md:14-28`)
+
+### Event-Driven Architecture
+- Event sourcing: immutable ordered log of all state-changing events; state derived by replay; enables audit trail, DR, testing (`01_Low-Latency.md:108-125`)
+- CQRS: separate write model (command handlers) from read model (projections for blotters, risk, compliance) (`01_Low-Latency.md:127-150`)
+- CEP engines: Esper, Apama (algo trading/surveillance), kdb+/q, Apache Flink, Kafka Streams; used for algo signals, risk monitoring, surveillance (`01_Low-Latency.md:160-178`)
+
+### High Availability
+- Active-Active: both sites process traffic; challenge is state sync and split-brain (`docs/trading-desk/07-infrastructure-and-architecture/02_High-Availability-And-System-Monitoring.md:7-22`)
+- Active-Passive: hot standby with <30s failover; warm standby with manual activation (`02_HA.md:24-39`)
+- RTO/RPO: OMS <2min/zero-loss, market data <30s, risk <1min/zero, post-trade <15min/<1min, analytics <1hr/<5min (`02_HA.md:41-49`)
+- Geo-redundant: Primary (co-lo), DR (nearby facility), Tertiary (different region), Office (`02_HA.md:59-68`)
+- Quarterly mandatory DR tests; chaos engineering; regulatory expectation (SEC, FCA, MAS) (`02_HA.md:70-75`)
+
+### Monitoring
+- SLA targets: 99.99% availability (<52 min/year), order ack <500us p99, market data <100us (co-lo), risk check <50us, failover <2min (`02_HA.md:129-140`)
+- Stack: Prometheus/InfluxDB + Grafana (dashboards), ELK/Splunk (logs), Corvil/Pico (wire-level nanosecond), Geneos (ITRS), Alertmanager/PagerDuty (`02_HA.md:102-127`)
+
+### Capacity Planning
+- Order entry: 1K-100K orders/sec with 5-10x peak multiplier; market data ingest: 1-10M msgs/sec per exchange with 3-5x peak (`03_Capacity-Planning.md:1-11`)
+- Exchange rate limits: CME iLink3 500 msgs/sec/session, Nasdaq 10K+, NYSE 1K/sec/MPID, Cboe 10K+ (`03_Capacity-Planning.md:30-40`)
+- OPRA peak: 100M+ msgs/sec (highest throughput feed globally) (`03_Capacity-Planning.md:42-52`)
+- Headroom: 30-50% CPU on critical path, 50% memory; hardware refresh 18-24 months (`03_Capacity-Planning.md:54-60`)
+
+### Database Considerations
+- kdb+/q: de facto standard for tick data; column-oriented, in-memory + memory-mapped; millions rows/sec ingest, billions queried in milliseconds (`03_Capacity-Planning.md:70-78`)
+- Relational: SQL Server (dominant .NET), Oracle (large banks), PostgreSQL (increasingly replacing both) (`03_Capacity-Planning.md:101-117`)
+- In-memory grids: Redis, Hazelcast, Oracle Coherence, Apache Ignite, Microsoft Garnet (.NET-optimized, Redis-compatible) (`03_Capacity-Planning.md:119-139`)
+- Common caches: instrument cache, position cache, price cache, order state cache, risk limit cache (`03_Capacity-Planning.md:133-139`)
+
+### Security
+- Network segmentation: Internet/DMZ -> Corporate -> Trading DMZ -> Trading Core (no internet) -> Exchange Connectivity (most restricted) (`docs/trading-desk/07-infrastructure-and-architecture/04_Security-And-Configuration-Management.md:1-33`)
+- Encryption: TLS 1.2+ for FIX, mTLS for internal cross-zone, TDE for data at rest, HashiCorp Vault / HSM for keys (`04_Security.md:35-43`)
+- Access: RBAC, entitlement management (instruments/venues/order types), four-eyes principle, PAM (CyberArk) (`04_Security.md:45-51`)
+- Audit logging: all order events, user actions, system events; 5-7 year retention; WORM storage; NTP/PTP sync to UTC (`04_Security.md:60-70`)
+
+## 8. Position Tracking, Multi-Currency Handling, P&L Calculations, Reconciliation, and SOD/EOD Procedures
+
+### Position Tracking
+- Position key: `(Account, Instrument, Settlement Date, Currency, Legal Entity)` (`docs/trading-desk/04-position-management/01_Real-Time-Position-Tracking.md:1-21`)
+- Core fields: Quantity (signed), AverageCost, MarketPrice, RealizedPnL, UnrealizedPnL, TotalPnL, Notional (`01_Position-Tracking.md:11-21`)
+- Realized P&L: `(ExitPrice - EntryCost) * ClosedQuantity * ContractMultiplier`; final and does not change (`01_Position-Tracking.md:39-53`)
+- Unrealized P&L: `(MarketPrice - AverageCost) * Quantity * ContractMultiplier`; changes with every tick (`01_Position-Tracking.md:55-71`)
+- MTM sources by type: listed equities (last trade/mid-quote), OTC derivatives (model price), fixed income (vendor evaluated price), FX (mid-rate), illiquid (stale price with flag) (`01_Position-Tracking.md:63-71`)
+
+### P&L Attribution
+- Decomposition: `TotalPnL = TradePnL + PositionPnL + CarryPnL + FxPnL + FeesAndCommissions` (`01_Position-Tracking.md:84-98`)
+- TradePnL = slippage vs arrival price; PositionPnL = market moves on SOD positions; CarryPnL = accrued interest/dividends/funding; FxPnL = currency moves on foreign positions (`01_Position-Tracking.md:84-98`)
+
+### Position Views and Aggregation
+- Dimensions: Account, Desk, Trader, Strategy, Instrument, Asset Class, Currency, Legal Entity, Sector, Geography, Counterparty, Custodian (`01_Position-Tracking.md:101-121`)
+- Implementation: materialized aggregations (low latency, high memory), on-demand roll-ups, or OLAP cubes (`01_Position-Tracking.md:122-130`)
+- Gross vs Net: Gross = sum(abs(qty)), Net = sum(qty signed), Gross Notional = sum(abs(qty * price * multiplier)) (`01_Position-Tracking.md:144-155`)
+- Netting levels: trade-level (no netting), position, account, legal entity, counterparty (ISDA), CCP (`01_Position-Tracking.md:157-169`)
+
+### Multi-Currency Handling
+- Base currency conversion: `Value_Base = Value_Local * FxRate(Local->Base)`; EOD using WM/Reuters 4pm London fix (`docs/trading-desk/04-position-management/02_Multi-Currency-Positions.md:1-14`)
+- Cross-currency P&L decomposition: `PnL_Base = (P1-P0)*FX0*Qty*Mult + P0*(FX1-FX0)*Qty*Mult + cross-term` (`02_Multi-Currency.md:32-55`)
+- Multi-currency cash ladder tracks SOD balance, buys, sells, fees, EOD balance, base equivalent per currency (`02_Multi-Currency.md:58-70`)
+
+### Margin Management
+- Reg T (US equities): 50% initial, 25% maintenance (FINRA min, brokers 30-40%) (`02_Multi-Currency.md:112-122`)
+- Portfolio margin: risk-based (TIMS/SPAN/OCC), typically 4-6x more buying power than Reg T for hedged portfolios (`02_Multi-Currency.md:76-100`)
+- SPAN: 16 scenarios (price ±3 std dev, vol ±1 shift); margin = max loss across all scenarios with inter-commodity spread offsets (`02_Multi-Currency.md:124-147`)
+- Margin call types: Reg T (T+2), Maintenance (T+3-5), Fed (T+2), Exchange (same day), House (immediate to T+3) (`02_Multi-Currency.md:149-166`)
+
+### Cost Basis and Tax Lots
+- Methods: FIFO (oldest first, default IRS), LIFO (newest first), Specific Identification (max control), Average Cost (mutual funds, UK) (`docs/trading-desk/04-position-management/05_Average-Cost-And-Tax-Lot-Tracking.md:9-65`)
+- Average cost: `(OldQty * OldAvgCost + NewQty * NewPrice) / (OldQty + NewQty)` (`05_Tax-Lot-Tracking.md:54-65`)
+- Wash sale (IRS Section 1091): loss disallowed if substantially identical security purchased within 30 days before/after; disallowed loss added to replacement basis (`05_Tax-Lot-Tracking.md:67-89`)
+- Multi-currency tax lots: record LocalPrice, FxRateAtPurchase, BaseCurrencyCost; realized P&L includes both local price and FX changes (`05_Tax-Lot-Tracking.md:91-111`)
+
+### Corporate Actions Impact
+- Stock splits: `NewQty = OldQty * Ratio`, `NewAvgCost = OldAvgCost / Ratio`; position value unchanged (`docs/trading-desk/04-position-management/04_Corporate-Actions-Impact-On-Positions.md:9-31`)
+- Cash dividends: receivable booked on ex-date, cash credited on pay-date; short sellers owe manufactured dividend (`04_Corporate-Actions.md:33-46`)
+
+### SOD/EOD Procedures
+- SOD: position snapshot from prior EOD, reconciliation against custodian/prime broker, corporate action processing, cash projection, margin requirement calculation (`docs/trading-desk/15-operational-workflows/01_Start-Of-Day-And-End-Of-Day-Procedures.md:3-30`)
+- EOD: official MTM snap, P&L calculation and sign-off, position reconciliation (internal vs external), margin/collateral calculations, trade and settlement reports, regulatory reports generation, data backup, next-day preparation (`01_SOD-EOD.md:32-65`)
+- SOD position: `SOD_Position = Prior_EOD_Position + Overnight_Adjustments (corporate actions, settlements, corrections)` (`01_SOD-EOD.md:3-30`)
+- EOD P&L sign-off: trader review, desk head review, risk manager review, finance/accounting validation (`01_SOD-EOD.md:32-65`)
+
+### Reconciliation
+- Trade reconciliation: internal OMS/EMS vs broker confirmations, exchange/venue reports, CCP records, custodian records (`docs/trading-desk/13-post-trade-processing/03_Reconciliation-And-Trade-Lifecycle-Events.md:5-27`)
+- Position reconciliation dimensions: quantity, market value, settled vs traded, tax lot (`03_Reconciliation.md:28-46`)
+- Cash reconciliation: settlement flows, income, corporate action flows, fees, margin, FX (`03_Reconciliation.md:47-62`)
+- Breaks management: automated matching with configurable tolerances, aging/escalation (T+1, T+3, T+5), target match rates 95%+ (`03_Reconciliation.md:63-75`)
+- Platforms: SmartStream TLM, Broadridge, Gresham Clareti, Duco, Bloomberg AIM (`03_Reconciliation.md:63-75`)
+
+## 9. Execution Algorithms, Smart Order Routing, Execution Quality, and Market Microstructure
+
+### Execution Algorithms
+- **VWAP**: targets volume-weighted average using 20-30 day rolling historical volume profile in 1-5-10 minute buckets; participation <15-20% per bucket (`docs/trading-desk/03-execution-and-algorithms/01_Execution-Algorithms-Part-1.md:5-46`)
+- **TWAP**: equal slices across N intervals regardless of volume; ±20-30% randomization with catch-up logic (`01_Algos-Part-1.md:49-76`)
+- **POV/Participation**: maintains target % of real-time consolidated tape volume, self-adapting (`01_Algos-Part-1.md:79-112`)
+- **Implementation Shortfall**: minimizes cost vs arrival price; cost model: market impact + timing risk + opportunity cost; square-root/power-law/Almgren-Chriss impact models (`01_Algos-Part-1.md:115-162`)
+- **MOC/Close**: 30-50% pre-close, 50-70% in auction; NYSE imbalance at 15:50 ET, irrevocable after 15:50 (NYSE)/15:55 (NASDAQ) (`docs/trading-desk/03-execution-and-algorithms/02_Execution-Algorithms-Part-2.md:3-34`)
+- **Iceberg/Reserve**: exchange-native or algo-managed; anti-detection via display variance, random delays 50-500ms, venue rotation (`02_Algos-Part-2.md:37-71`)
+- **Sniper/Liquidity Seeking**: passive monitoring then aggressive take; dark pool pinging min 100-200 shares, controlled frequency (`02_Algos-Part-2.md:74-109`)
+- **Dark Pool**: dark-only or dark-preferring; fill probability models using logistic regression or gradient boosted models (`02_Algos-Part-2.md:112-140`)
+- **Pairs Trading**: simultaneous execution of two correlated legs; ratio-based or spread-based; hard leg (less liquid) first (`02_Algos-Part-2.md:143-170`)
+- **Adaptive/Multi-Strategy**: dynamic switching based on momentum, volatility, spread dynamics, order book imbalance; ML-driven (`02_Algos-Part-2.md:173-192`)
+
+### Algorithm Parameters
+- Urgency levels: PASSIVE (3-5% participation), LOW (5-10%), MEDIUM (10-20%), HIGH (20-35%), AGGRESSIVE (35-50%), HYPER (50%+) (`docs/trading-desk/03-execution-and-algorithms/03_Algorithm-Parameters-And-Customization.md:22-34`)
+- FIX strategy params: Tag 847 (StrategyParametersGrp), Tag 958/959/960; FIXatdl XML schema for parameter definitions (`03_Algo-Params.md:69-83`)
+
+### Smart Order Routing
+- US lit venues: NYSE, NASDAQ, NYSE Arca, BATS BZX/BYX, IEX, EDGX/EDGA, NYSE American, LTSE, MEMX, MIAX Pearl (`docs/trading-desk/03-execution-and-algorithms/04_Smart-Order-Routing.md:8-23`)
+- Dark pools: UBS ATS, CrossFinder, Sigma-X2, MS Pool, JPM-X, MatchIt, Citadel Connect, Level ATS, IntelligentCross (`04_SOR.md:24-35`)
+- Fee optimization: standard maker-taker (NYSE Arca: -$0.0020 maker rebate, +$0.0030 taker fee) vs inverted (BATS BYX: +$0.0004 maker fee, -$0.0005 taker rebate) (`04_SOR.md:52-72`)
+- SOR decision flow: determine intent -> evaluate dark pools -> if aggressive, score venues and route IOC -> if passive, evaluate queue position and route to best rebate (`04_SOR.md:125-140`)
+
+### Execution Quality Measurement (TCA)
+- Cost components: explicit (commission, fees, taxes) + implicit (spread, market impact, timing, opportunity, delay) (`docs/trading-desk/03-execution-and-algorithms/07_Execution-Quality-Measurement.md:9-24`)
+- Benchmarks: Arrival Price (most popular for IS), VWAP, TWAP, Close, Open, Previous Close (`07_TCA.md:25-36`)
+- IS decomposition: `Total IS = Delay Cost + Trading Cost + Opportunity Cost`; `Trading Cost = Impact + Timing + Spread` (`07_TCA.md:37-64`)
+- Per-order metrics: Arrival Slippage (bps), VWAP Slippage, Spread Capture, Fill Rate, Participation Rate, Time to Fill (`07_TCA.md:65-76`)
+- TCA vendors: Abel Noser, ITG/Virtu, Bloomberg BTCA, Liquidmetrix (`07_TCA.md:87-108`)
+
+### Market Microstructure
+- Spread determinants: volatility, volume, tick size, market makers, information asymmetry; intraday pattern widest at open, narrows through day (`docs/trading-desk/03-execution-and-algorithms/10_Market-Microstructure.md:3-32`)
+- US tick size: $0.01 for stocks >= $1.00 (Rule 612 Sub-Penny), $0.0001 for <$1.00 (`10_Microstructure.md:3-32`)
+- Order book imbalance: `(bid_size - ask_size) / (bid_size + ask_size)` predictive of short-term price direction (`10_Microstructure.md:33-54`)
+- Queue priority: Price-Time/FIFO (most US), Price-Size-Time, Pro-Rata (CME Eurodollar), Price-Display-Time (`10_Microstructure.md:91-120`)
+- Venue toxicity: VPIN `|buy_vol - sell_vol| / total_vol` (high = toxic); spread decomposition into adverse selection/inventory/processing components (`docs/trading-desk/03-execution-and-algorithms/08_Execution-Venue-Analysis.md:48-78`)
+
+## 10. Post-Trade Processing, Audit Trail Requirements, and Compliance/Regulatory Reporting
+
+### Trade Confirmation and Settlement
+- Matched fields: trade date, settlement date, ISIN/CUSIP/SEDOL, side, quantity, price, currency, counterparty (BIC/LEI), accrued interest, net amount (`docs/trading-desk/13-post-trade-processing/01_Trade-Confirmation-And-Clearing-Settlement.md:5-35`)
+- SEC Rule 15c6-2 (May 2024): allocations, confirmation, affirmation by end of trade date (`01_Confirmation.md:36-50`)
+- DTCC/Omgeo CTM: trade submission -> central matching -> exception handling -> affirmation -> DTC settlement; SDA target >90% (`01_Confirmation.md:51-73`)
+- Settlement cycles: US/Canada T+1 (May 2024), EU/UK/HK/Japan/Australia T+2 (`01_Confirmation.md:118-145`)
+- Fails: CSDR penalties (EU) based on instrument type; resolution via buy-in, partial settlement, securities lending, shaping (`01_Confirmation.md:146-167`)
+
+### CCP Clearing
+- Key CCPs: NSCC (US equities), OCC (options), LCH (EU swaps/CDS), Eurex Clearing, ICE Clear Europe (`01_Confirmation.md:78-106`)
+- Process: trade capture -> novation -> margining (IM + VM) -> netting -> settlement instruction (`01_Confirmation.md:78-106`)
+- Bilateral clearing: ISDA confirmation, ISDA CSA collateral, UMR for uncleared OTC derivatives >$8B AANA (`01_Confirmation.md:107-117`)
+
+### Allocation and Corporate Actions
+- Block allocation: pre-trade intent -> execution -> allocation instruction -> matching -> booking; allocations by EOD per SEC 15c6-2 (`docs/trading-desk/13-post-trade-processing/02_Trade-Allocation-And-Corporate-Actions.md:3-27`)
+- Average price: FINRA 5320.02 permits for institutional; all accounts receive same per-share price (`02_Allocation.md:43-58`)
+- Corporate actions: cash dividends, stock splits, mergers, spinoffs tracked via DTCC GCA, SWIFT MT564-568, Bloomberg CACS (`02_Allocation.md:61-120`)
+
+### Reconciliation
+- Trade recon: OMS/EMS vs broker vs exchange vs CCP vs custodian; intraday + T+0 evening definitively for T+1 settlement (`docs/trading-desk/13-post-trade-processing/03_Reconciliation-And-Trade-Lifecycle-Events.md:5-27`)
+- Breaks management: automated matching, aging/escalation (T+1/T+3/T+5), target 95%+ match rates (`03_Reconciliation.md:63-75`)
+- Trade lifecycle: amendments (modify terms, counterparty agreement, audit trail), cancellations (cancel-and-rebook, downstream notification), late trades (NAV impact monitoring) (`03_Reconciliation.md:78-150`)
+
+### STP and Middle Office
+- STP rates: trade capture 99%+, allocation 95%+, confirmation 90-95%, end-to-end 85-95%; listed equities 95%+, corporate bonds 70-85%, OTC derivatives 50-70% (`docs/trading-desk/13-post-trade-processing/05_STP-Exception-Management-Middle-Office-And-Glossary.md:3-28`)
+- Trade enrichment: SSI lookup, fees/commissions, accrued interest, tax lot assignment, regulatory classification, FX conversion (`05_STP.md:86-99`)
+
+### Audit Trail Requirements
+- MiFID II RTS 25: all order decisions (including algo ID), submissions, modifications, cancellations, executions with millisecond timestamps (microsecond for HFT) (`docs/trading-desk/14-compliance-and-regulatory/05_Record-Keeping-Requirements.md:1-26`)
+- SEC Rule 17a-3/17a-4: blotters, customer records, order tickets, confirmations, trial balances (`05_Record-Keeping.md:1-26`)
+- Clock sync: MiFID II 1us (HFT), 1ms (electronic), 1s (non-electronic); FINRA/CAT within 50ms of NIST (`05_Record-Keeping.md:22-26`)
+- Communication records: telephone, Bloomberg chat, Symphony, email; off-channel (WhatsApp) subject of $2B+ enforcement fines 2021-2024 (`05_Record-Keeping.md:27-43`)
+- Retention: MiFID II 5 years, SEC 17a-4 blotters 6 years / order tickets 3 years, EMIR 5 years after termination, SFTR 10 years (`05_Record-Keeping.md:44-64`)
+- WORM storage required under SEC 17a-4(f) (`05_Record-Keeping.md:44-64`)
+
+### Regulatory Reporting
+- MiFID II Article 26: T+1 to NCA via ARM; 65 fields including LEI, national ID, algo ID, short sale indicator (`docs/trading-desk/14-compliance-and-regulatory/03_Regulatory-Reporting.md:5-35`)
+- EMIR Refit (April 2024): 203 fields (up from 129), mandatory ISO 20022 XML, UTI/UPI alignment (`03_Regulatory-Reporting.md:36-57`)
+- Dodd-Frank: CFTC Part 43 real-time within 15-30 min, Part 45 regulatory data to SDRs (`03_Regulatory-Reporting.md:59-78`)
+- CAT (SEC Rule 613): every order event for US equities/options; replaces OATS; microsecond timestamps for electronic; T+3 error correction (`03_Regulatory-Reporting.md:79-94`)
+- SEC Rule 606: quarterly routing disclosure for non-directed orders; customer-specific on request within 7 business days (`03_Regulatory-Reporting.md:108-122`)
+
+### Best Execution
+- Metrics: price improvement %, effective vs quoted spread, IS decomposition, VWAP slippage, fill rates, latency, reversion (5s/1m/5m/30m) (`docs/trading-desk/14-compliance-and-regulatory/04_Best-Execution-Monitoring-And-Reporting.md:1-50`)
+- MiFID II RTS 28: annual report of top 5 venues by volume per instrument class, separately for retail/professional (`04_Best-Execution.md:1-50`)
+
+## 11. Trading UI Components, Workspace Layouts, Keyboard Patterns, and Dashboard/Analytics Views
+
+### Order Entry Tickets
+- Single-stock: Symbol, Side, Quantity, Order Type, Limit/Stop Price, TIF, Account, Destination, Algo with sub-parameters panel; fat-finger and price reasonability checks (`docs/trading-desk/16-trading-ui-components/01_Order-Entry-Tickets-And-Trading-Blotter.md:5-40`)
+- Multi-leg/options: strategy template, legs table, net debit/credit, greeks display (delta/gamma/theta/vega), P&L payoff diagram (`01_Order-Entry.md:42-63`)
+- FX ticket: deal type (Spot/Forward/Swap/NDF), notional toggle, tenor shortcuts, streaming bid/ask (`01_Order-Entry.md:65-83`)
+- Fixed income: CUSIP/ISIN/SEDOL, price type (clean/yield/spread/OAS), benchmark selection, RFQ mode (`01_Order-Entry.md:85-104`)
+- Keyboard shortcuts: `F2`/`/` symbol search, `B` buy, `S` sell, `Enter` submit, `+/-` tick price, `Ctrl+Up/Down` quantity (`01_Order-Entry.md:116-130`)
+
+### Blotters
+- Order blotter columns: Order ID, Time, Symbol, Side, Qty, Filled, Remaining, Type, Limit Price, Avg Fill, TIF, Status, Account, Algo, % Complete, Trader (`01_Order-Entry.md:137-162`)
+- Status colors: New (light blue), Acknowledged (blue), Partially Filled (yellow), Filled (green), Cancelled (gray), Rejected (red), Expired (dark gray), Replaced (purple), Pending Cancel (orange) (`01_Order-Entry.md:164-178`)
+- Execution blotter: microsecond precision timestamps, Venue, Liquidity (Add/Remove), Avg Price formula `SUM(FillQty_i * FillPrice_i) / SUM(FillQty_i)` (`docs/trading-desk/16-trading-ui-components/02_Execution-Blotter-And-Position-Blotter.md:1-50`)
+- Position blotter: net quantity, avg cost, last price, unrealized/realized/total P&L, day P&L, beta-adj exposure; flash green/red on tick; heat map treemap view (`02_Position-Blotter.md:53-115`)
+
+### Market Data Displays
+- Watchlist: symbol, last, change, bid/ask/spread, volume, VWAP, OHLC; typeahead supporting ticker/name/CUSIP/ISIN (`docs/trading-desk/16-trading-ui-components/03_Market-Data-Displays.md:4-39`)
+- Level 2 / Market Depth: bid/ask sides with price/size/orders columns, size bars, click-to-trade, depth chart visualization (`03_Market-Data-Displays.md:55-84`)
+- Time and Sales: microsecond timestamps, color: green (at ask/uptick), red (at bid/downtick), gray (mid); cumulative buy/sell volume (`03_Market-Data-Displays.md:86-111`)
+
+### Charting
+- Types: Candlestick, Bar, Line, Area, Heikin-Ashi, Renko, Point & Figure, Volume Profile (`docs/trading-desk/16-trading-ui-components/03_Market-Data-Displays.md` charting section)
+- Timeframes: 1-tick through yearly; multi-timeframe 2x2 layout (`03_Market-Data-Displays.md` charting section)
+- Indicators: SMA, EMA, VWAP, Ichimoku, RSI (14), MACD (12,26,9), Stochastic, Bollinger (20,2), ATR, Volume Profile (`03_Market-Data-Displays.md` charting section)
+- Drawing tools: trend/horizontal/vertical lines, channels, Fibonacci retracement/extension, pitchfork, patterns; snap-to-price, alert-on-cross (`03_Market-Data-Displays.md` charting section)
+
+### Workspace Management
+- Layout: tabbed panels, split panes, floating windows, docking system with visual guides (`docs/trading-desk/16-trading-ui-components/06_Workspace-Keyboard-And-UX-Patterns.md:3-12`)
+- Typical 6-monitor arrangement: watchlists (top-left), charts 2x2 (top-center), news (top-right), order/execution blotters (bottom-left), positions/L2 (bottom-center), risk/alerts (bottom-right) (`06_Workspace.md:14-23`)
+- Symbol linking: color-coded groups (Red, Blue, Green, Yellow); components in same group share selected symbol (`06_Workspace.md:45-50`)
+- Workspace save/load: named workspaces, auto-save, export/import, all component state preserved (`06_Workspace.md:25-35`)
+
+### Keyboard-Driven Trading
+- Global: `Ctrl+N` new order, `Ctrl+Shift+B` quick-buy, `Ctrl+Shift+S` quick-sell, `Ctrl+F` command palette, `Ctrl+1-9` switch workspace, `F11` fullscreen (`06_Workspace.md:64-78`)
+- Order management: `Ctrl+Shift+C` cancel selected, `Ctrl+Shift+A` cancel all for symbol, `Ctrl+Shift+X` cancel all (panic), `Ctrl+Shift+F` flatten position, `Ctrl+Shift+P` flatten all (`06_Workspace.md:80-89`)
+- Speed trader: pre-configured templates bound to keys, numeric pad quantity entry, price ladder (DOM) one-click trading (`06_Workspace.md:91-102`)
+- Command palette: `Ctrl+Shift+P`, searches symbols/actions/components/settings/recent (`06_Workspace.md:104-112`)
+- Customizable keybindings with conflict detection, context-aware, chord support (`06_Workspace.md:114-120`)
+
+### UX Patterns
+- Dark theme dominant; green=positive/buy, red=negative/sell (inversible for Asian markets) (`06_Workspace.md:126-130`)
+- Cell flash 200-500ms on update, tick arrows, stale data indicator (dimmed after 5s), connection status indicator (`06_Workspace.md:132-136`)
+- Performance: market data 1-5ms co-lo, blotter update 1ms after FIX, chart 60fps (16ms), startup 5-15s, memory 2-8GB (`06_Workspace.md:146-152`)
+
+### Dashboards
+- P&L dashboard: summary bar (Day/MTD/YTD P&L), intraday chart with ±1 std dev band, breakdown by strategy/trader; drill-down to position to execution (`docs/trading-desk/17-dashboard-and-analytics/01_Real-Time-Dashboards.md:1-40`)
+- Risk dashboard: VaR/CVaR, net/gross exposure, greeks, limit monitoring (green/yellow/orange/red), scenario analysis panel, greeks surface (3D delta/gamma/vega) (`01_Dashboards.md:42-87`)
+- Execution dashboard: fill rate, cancel rate, VWAP slippage, IS, quality by venue and by algo (`01_Dashboards.md:89-128`)
+
+### Portfolio Analytics
+- Brinson attribution: Allocation Effect + Selection Effect + Interaction Effect = Total Active Return (`docs/trading-desk/17-dashboard-and-analytics/03_Performance-Attribution.md:1-26`)
+- Factor attribution: Market/Size/Value/Momentum/Quality/Industry/Country/Currency/Specific contributions (`03_Attribution.md:28-47`)
+- Factor exposure: Barra/Axioma/Northfield models; factor contribution to return and risk decomposition (`docs/trading-desk/17-dashboard-and-analytics/02_Portfolio-Analytics.md:79-99`)
+
+### Data Visualization
+- Heat maps: position (size=market value, color=P&L%), correlation (blue +1 to red -1), sector (treemap) (`docs/trading-desk/17-dashboard-and-analytics/05_Data-Visualization.md:1-27`)
+- Volatility surfaces: 3D plot (expiration x strike x IV), 2D slices (smile/skew, term structure) (`05_Visualization.md:102-131`)
+- Yield curves: spot/forward/spread/real/breakeven; slope indicators (2s10s, 3m10y) (`05_Visualization.md:76-100`)
+
+### Custom Analytics
+- Formula columns: spreadsheet-like calculated columns in blotters/watchlists, real-time recalculation (`docs/trading-desk/17-dashboard-and-analytics/06_Custom-Analytics-And-Scripting.md:1-38`)
+- Screening: universe selector, criteria builder, predefined scans (unusual volume, 52w highs, gap up/down, RSI extremes) (`06_Custom-Analytics.md:72-94`)
+- Backtesting: entry/exit rules, position sizing, commission/slippage; output metrics including Sharpe, Sortino, max drawdown (`06_Custom-Analytics.md:96-125`)
+
+### Compliance Views
+- Trade surveillance: spoofing, wash trading, front-running, insider trading, marking the close; investigation workflow with timeline reconstruction (`docs/trading-desk/17-dashboard-and-analytics/07_Audit-And-Compliance-Views.md:1-63`)
+- Communication monitoring: keyword detection, sentiment analysis, trade-communication correlation; 5-7 year retention (`07_Compliance-Views.md:65-87`)
+
+### Dashboard Design Principles
+- Refresh rates: prices streaming 1-50ms, P&L per tick or 1s, risk 1s-1min, attribution 15-60min or EOD (`docs/trading-desk/17-dashboard-and-analytics/08_Dashboard-Design-Principles.md:10-20`)
+- Interactivity: drill-down on every number, cross-filtering, tooltip on hover, CSV/XLSX/PDF/PNG export, Ctrl+Z undo (`08_Design-Principles.md:22-29`)
+
+## 12. Cryptocurrency-Specific Derivatives Features Related to Kraken Integration
+
+### CME Bitcoin Futures
+- Contract size: 5 BTC; tick size $5/BTC ($25/contract); cash-settled to CME CF Bitcoin Reference Rate (BRR) (`docs/trading-desk/12-futures-and-listed-derivatives/05_Cryptocurrency-Derivatives.md:3-13`)
+- BRR calculated from 5 exchanges: Coinbase, Kraken, Bitstamp, Gemini, LMAX Digital at 4:00 PM London time (`05_Crypto-Derivatives.md:10`)
+- Trading hours: Sun-Fri 5:00 PM - 4:00 PM CT; margin ~40-50% of notional (`05_Crypto-Derivatives.md:3-13`)
+- Micro Bitcoin (MBT): 0.1 BTC, $5/BTC ($0.50/contract) (`05_Crypto-Derivatives.md:15-19`)
+- CME Ether Futures: 50 ETH, $0.25/ETH ($12.50/contract), cash-settled to CME CF Ether-Dollar Reference Rate (`05_Crypto-Derivatives.md:21-24`)
+- Bitcoin Options on CME: European, 5 BTC, monthly/weekly, Black-76 model (`05_Crypto-Derivatives.md:26-33`)
+
+### Perpetual Swaps (Crypto-Native)
+- No expiration; tracks spot via funding rate exchanged every 8 hours (`05_Crypto-Derivatives.md:35-56`)
+- Funding rate formula: `FundingRate = PremiumIndex + clamp(InterestRate - PremiumIndex, -0.05%, 0.05%)` where `PremiumIndex = (MarkPrice - IndexPrice) / IndexPrice` (`05_Crypto-Derivatives.md:44-50`)
+- Positive rate: longs pay shorts (premium to spot); negative: shorts pay longs (`05_Crypto-Derivatives.md:44-50`)
+- Leverage up to 125x on some exchanges; professionals use 1-10x (`05_Crypto-Derivatives.md:35-56`)
+- Liquidation: when unrealized loss exceeds maintenance margin; insurance fund covers shortfalls; auto-deleveraging (ADL) as last resort (`05_Crypto-Derivatives.md:56-58`)
+- Mark price: multi-exchange index to prevent manipulation-driven liquidations (`05_Crypto-Derivatives.md:58`)
+
+### CME vs Perpetual Comparison
+- CME: monthly/quarterly expiration, cash-settled, CFTC-regulated, CCP-cleared, ~2-2.5x leverage, 23hr/5day; Perpetuals: no expiration, funding rate, largely unregulated, exchange risk, up to 125x, 24/7/365 (`05_Crypto-Derivatives.md:60-71`)
+
+### Crypto Options
+- Deribit: ~90% global crypto options volume; European, cash-settled, portfolio margining, block trading (`05_Crypto-Derivatives.md:73-83`)
+
+### Margin and Clearing
+- CME: SPAN margin with 16 scenarios, ~40-50% for crypto (higher than traditional due to volatility) (`docs/trading-desk/12-futures-and-listed-derivatives/03_Clearing-Margining-And-Settlement.md:24-32`)
+- Variation margin: CME daily (often intraday for large moves); perpetuals continuous or 8-hourly (`03_Clearing.md:34-42`)
+
+### Basis Trading (Kraken Integration)
+- Basis = Futures Price - Spot Price; fair value via cost-of-carry: `Spot * e^((r-q)*T)` (`docs/trading-desk/12-futures-and-listed-derivatives/06_Cross-Margining-And-Basis-Trading.md:58-78`)
+- Cash-and-carry arbitrage: buy spot on Kraken, sell CME futures, hold to expiration; profit = (Futures - Fair Value) - financing costs (`06_Basis-Trading.md:87-102`)
+- Perpetual basis: no convergence date; funding rate creates carry; buy spot + short perpetual when premium exists (`06_Basis-Trading.md` implied from perpetual mechanism)
+- Kraken is one of five BRR constituent exchanges, making it directly relevant to CME settlement calculations (`05_Crypto-Derivatives.md:10`)
+
+## Cross-cutting observations
+
+- **Authentication pattern consistency**: Both Kraken spot and futures APIs use HMAC-SHA512 with base64-decoded secrets and SHA256 intermediate hashing, but differ in input construction (spot: URI+SHA256(nonce+POST); futures: SHA256(postData+nonce+path)) (`01_Authentication.md:22-24`, `03_Rest.md:26-35`)
+- **FIX protocol pervasive**: FIX protocol appears as the lingua franca across order management (`01_FIX-Protocol.md`), execution reports (`01_Execution-Report.md`), Kraken spot FIX API (`04-spot-fix/`), and market data (`03_Data-Normalization.md:67-75`), with consistent tag numbering throughout
+- **Three Kraken connectivity modes**: spot exchange offers REST, WebSocket v1/v2, and FIX APIs; futures offers REST and WebSocket; no futures FIX documented in repo
+- **Event sourcing alignment**: the documented event-driven architecture (`01_Low-Latency.md:108-125`) and CQRS patterns (`01_Low-Latency.md:127-150`) align with the immutable audit trail requirements from compliance (`05_Record-Keeping.md:60-70`)
+- **Pure Zig constraint**: no existing source code exists in the repository; all documentation is in `docs/` directory; the CLAUDE.md notes the project targets .NET/C# but memory indicates actual direction is Zig with zero external dependencies
+- **Documentation is comprehensive**: the `docs/trading-desk/` directory contains 17 major sections with detailed specifications covering all aspects of a professional trading desk; `docs/kraken-exchange-documentation/` contains 8 major sections with full API specifications
+
+## Coverage gaps
+
+- No gaps identified. All 12 questions have corresponding findings with file:line references from the documentation.

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/03-design-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/03-design-01.md
@@ -1,0 +1,137 @@
+---
+phase: 3
+iteration: 01
+generated: 2026-04-03
+---
+
+# Design: Trading Platform SDK (Pure Zig) with Kraken Exchange Integration
+
+Research: .claude/specs/trading-desk-kraken-integration/02-research-01.md
+
+## Current State
+
+No source code exists. The repository contains comprehensive documentation:
+- `docs/trading-desk/` — 17 sections covering all aspects of a professional trading desk (market data, OMS, execution, risk, positions, connectivity, infrastructure, post-trade, compliance, UI, analytics) (`02-research-01.md:558`)
+- `docs/kraken-exchange-documentation/` — 8 sections with full API specs for spot REST/WS/FIX and futures REST/WS (`02-research-01.md:555-558`)
+- CLAUDE.md references .NET/C# but actual direction is pure Zig with zero external dependencies (`02-research-01.md:557`)
+
+## Desired End State
+
+A complete, pure-Zig SDK providing every building block needed for a professional trading platform. All components built natively — no external libraries, no C interop, no `.zon` dependencies. The SDK is a layered library consumed by exchange adapters (Kraken first) and trading applications. The design document serves as an architectural blueprint documenting how to build each component.
+
+## Patterns to Follow
+
+- **Gateway/adapter architecture**: Internal trading core communicates with per-venue gateways that handle protocol translation, session management, symbol mapping, and rate limiting — found at `02-research-01.md:239-241`
+- **Event sourcing + CQRS**: Immutable ordered event log as the system of record; separate write (command) and read (projection) models — found at `02-research-01.md:274-275`
+- **Lock-free structures on hot path**: Ring buffers, SPSC/MPSC queues, object pooling, cache-line alignment (64 bytes) for zero-contention data flow — found at `02-research-01.md:264-265`
+- **Pre-trade risk pipeline**: Sequential validation stages (order validation → price check → size limits → position limits → credit check → rate throttle → duplicate check) — found at `02-research-01.md:193`
+- **HMAC-SHA512 auth pattern**: Both Kraken spot and futures use HMAC-SHA512 with base64-decoded secrets, differing only in input construction — found at `02-research-01.md:553`
+- **FIX protocol as lingua franca**: FIX tag-value encoding used across OMS, execution reports, market data, and Kraken's FIX API — found at `02-research-01.md:554`
+
+## Patterns to Avoid
+
+- **GC-based runtimes**: Research documents GC mitigation techniques (.NET `GC.TryStartNoGCRegion`, Java ZGC) as workarounds — found at `02-research-01.md:266`. Zig eliminates this entire problem class through explicit allocation.
+- **External dependency chains**: Research references QuickFIX/J, QuickFIX/N, Chronicle FIX, etc. — found at `02-research-01.md:234-235`. These introduce C/C++/Java interop. All protocol implementations will be native Zig.
+- **Kernel networking for hot path**: Research documents kernel bypass (OpenOnload, DPDK) reducing NIC-to-app latency from ~10us to ~1-2us — found at `02-research-01.md:152`. The SDK will use io_uring as the primary I/O model, avoiding kernel TCP/IP stack overhead where possible.
+
+## Resolved Design Decisions
+
+| Decision | Choice | Reason |
+| --- | --- | --- |
+| SDK scope | Full platform | All components documented as native Zig building blocks; covers entire trading desk |
+| Module layout | Layered by abstraction | sdk/core → sdk/protocol → sdk/domain; strict dependency direction; exchanges/ and trading/ as consumers |
+| TLS | Custom TLS 1.2/1.3 | Built on Zig std.crypto primitives (AES-GCM, ChaCha20-Poly1305, X25519, RSA, ECDSA, X.509); full control |
+| Memory model | Arena + pool allocators | Cache-line aligned (64 bytes), pre-allocated pools for hot-path objects, huge page support via mmap |
+| Serialization formats | All: JSON, FIX, SBE, FAST, ITCH, OUCH, PITCH | Exchange-ready from day one; covers Kraken and all traditional/electronic venues |
+| Concurrency model | io_uring + dedicated pinned threads | io_uring event loop for general I/O; pinned threads with SPSC ring buffers for high-throughput feeds |
+| Order book | L2 + L3 with shared BookView | Market-by-Price for Kraken/simple feeds; Market-by-Order for MBO exchanges; common query interface |
+| Event store | Built-in append-only log | Sequence numbers, nanosecond timestamps, replay capability; satisfies audit trail requirements |
+| Tick storage | Custom columnar + Parquet export | Column-oriented binary for real-time ingest; Parquet writer for offline analysis ecosystem |
+
+## Approach
+
+### Layer 1: sdk/core — Foundational Primitives
+
+The core layer has zero dependencies beyond Zig's compiler builtins and provides:
+
+**Memory management** (`core/memory.zig`): Arena allocator for request-scoped work (bulk free on scope exit), fixed-size pool allocator with slab allocation for hot-path objects (orders, book levels, events), and a huge-page allocator wrapping `mmap` with `MAP_HUGETLB`. All allocators conform to Zig's `std.mem.Allocator` interface. Pool allocator aligns all allocations to 64-byte cache lines.
+
+**Cryptography** (`core/crypto/`): HMAC-SHA512 and SHA256 for Kraken authentication (`02-research-01.md:14-15`), Base64 encode/decode for API secrets, AES-128-GCM and AES-256-GCM for TLS record protection, ChaCha20-Poly1305 as alternative cipher suite, X25519 for TLS key exchange, RSA-PKCS1v15 and ECDSA-P256/P384 for X.509 certificate signature verification. Zig's `std.crypto` provides the underlying primitives; the SDK wraps them into trading-specific interfaces (e.g., `KrakenAuth.sign()`).
+
+**Containers** (`core/containers/`): SPSC ring buffer (single-producer/single-consumer, lock-free, cache-line padded head/tail pointers) for inter-thread communication. MPSC queue for multiple producers feeding a single consumer. Fixed-capacity hash map with open addressing for order-ID lookups. Sorted array with binary search for price levels.
+
+**Time** (`core/time.zig`): Nanosecond-precision timestamps from `CLOCK_MONOTONIC_RAW` (for latency measurement) and `CLOCK_REALTIME` (for wall-clock). Conversion between Unix nanoseconds, RFC3339 (Kraken WS v2, `02-research-01.md:40`), ISO8601 (Kraken Futures, `02-research-01.md:89`), and FIX UTCTimestamp formats.
+
+**I/O** (`core/io/`): io_uring-based event loop wrapping `std.os.linux.IoUring` — submission/completion ring management, socket read/write, timer scheduling, buffer registration for zero-copy receives. Thread pinning via `sched_setaffinity` with NUMA-aware core selection. TCP connection management with configurable timeouts.
+
+**Event store** (`core/event_store.zig`): Append-only memory-mapped file with 64-bit sequence numbers and 128-bit nanosecond timestamps. Zero-copy reads via mmap. Sequence gap detection for integrity. Replay iterator for state reconstruction. Date-partitioned files for retention management.
+
+### Layer 2: sdk/protocol — Wire Protocols
+
+The protocol layer depends only on core and implements every wire format:
+
+**TLS** (`protocol/tls/`): Custom TLS 1.2 and 1.3 client implementation. Handshake state machine (ClientHello → ServerHello → certificate validation → key exchange → Finished). Cipher suites: TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256 for TLS 1.3; TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 for TLS 1.2. X.509 certificate chain validation against a bundled CA store. Session resumption via tickets. Built on core crypto primitives.
+
+**HTTP** (`protocol/http/`): HTTP/1.1 client built on TLS. Request/response parsing with zero-copy headers. Connection pooling and keep-alive. Chunked transfer encoding. URL parsing. Sufficient for all Kraken REST endpoints (`02-research-01.md:21-35`).
+
+**WebSocket** (`protocol/websocket/`): RFC 6455 implementation over HTTP upgrade. Frame parsing (text, binary, ping, pong, close). Automatic ping/pong for keepalive (Kraken requires ~1 min, `02-research-01.md:42`). Reconnection logic with Cloudflare rate limit awareness (150 reconnects per 10 min, `02-research-01.md:42`). Message fragmentation and reassembly.
+
+**JSON** (`protocol/json.zig`): Streaming pull parser (SAX-style) for zero-allocation parsing of large responses. DOM builder for smaller payloads. Serializer with compile-time struct reflection. Handles Kraken's `result`/`error` response format (`02-research-01.md:33`).
+
+**FIX** (`protocol/fix/`): FIX 4.2, 4.4, and 5.0 SP2 tag-value codec (`02-research-01.md:225`). Session layer (FIXT 1.1): Logon/Logout, Heartbeat/TestRequest, ResendRequest/SequenceReset with PossDupFlag handling. Sequence number persistence across disconnections (`02-research-01.md:228`). SOH delimiter parsing, checksum (tag 10) validation. Message type dispatch. Covers Kraken FIX API (`02-research-01.md:45-51`) and traditional exchange connectivity.
+
+**SBE** (`protocol/sbe.zig`): Simple Binary Encoding for CME MDP 3.0 and Eurex T7 (`02-research-01.md:144`). Schema-driven zero-copy decoder — fixed-layout binary with compile-time field offset calculation. Message header parsing, group and vardata handling.
+
+**FAST** (`protocol/fast.zig`): FIX Adapted for Streaming — presence maps, stop-bit encoding, delta/increment operators (`02-research-01.md:143`). Template-driven decoder for compressed market data feeds.
+
+**ITCH** (`protocol/itch.zig`): NASDAQ TotalView-ITCH unidirectional binary protocol. Message types: Add Order (A/F), Execute (E/C), Cancel (X), Delete (D), Replace (U), Trade (P) (`02-research-01.md:145`). Fixed-width messages, no framing — length-prefixed on TCP.
+
+**OUCH** (`protocol/ouch.zig`): Order entry companion to ITCH (`02-research-01.md:146`). Enter Order, Replace Order, Cancel Order, and execution/cancel confirmations.
+
+**PITCH** (`protocol/pitch.zig`): Cboe binary protocol, similar to ITCH (`02-research-01.md:147`). Add Order, Execute, Cancel, Trade messages with multicast UDP transport support.
+
+### Layer 3: sdk/domain — Trading Domain Models
+
+The domain layer depends on core and protocol, implementing business logic:
+
+**Order book** (`domain/orderbook.zig`): L2 (Market-by-Price) using sorted price-level arrays with O(1) top-of-book and O(log n) insert. L3 (Market-by-Order) using price-level map with per-level doubly-linked order queues and order-ID hash map for O(1) lookup. Shared `BookView` interface for best bid/ask, depth, spread, mid-price. Book builder from ITCH/SBE incremental messages with sequence gap detection (`02-research-01.md:163-164`).
+
+**Order state machine** (`domain/oms.zig`): FIX-standard OrdStatus states — PendingNew, New, PartiallyFilled, Filled, Cancelled, Replaced, PendingCancel, Rejected, Suspended, PendingReplace, Expired (`02-research-01.md:102`). Validated state transitions with race condition handling: fill-before-cancel, fill-before-replace, unsolicited cancel (`02-research-01.md:107`). Order versioning with ClOrdID/OrigClOrdID linkage (`02-research-01.md:111`). Internal states: Staged, Validating, RoutePending (`02-research-01.md:110`).
+
+**Order types** (`domain/order_types.zig`): Market, Limit, Stop, Stop-Limit, Trailing Stop with FIX tag mappings (`02-research-01.md:94-99`). Time-in-force: Day, GTC, IOC, FOK, GTD (`02-research-01.md:95`). Bracket orders (primary + take-profit + stop-loss), OCO pairs, contingent orders (`02-research-01.md:122-125`). Parent-child relationships with quantity invariants (`02-research-01.md:121`).
+
+**Position tracking** (`domain/positions.zig`): Position keyed by (Account, Instrument, SettlementDate, Currency, LegalEntity) (`02-research-01.md:310`). Real-time realized and unrealized P&L (`02-research-01.md:312-313`). Cost basis methods: FIFO, LIFO, specific identification, average cost (`02-research-01.md:338`). Multi-currency with base currency conversion (`02-research-01.md:327`). P&L attribution decomposition: TradePnL + PositionPnL + CarryPnL + FxPnL + Fees (`02-research-01.md:317`).
+
+**Pre-trade risk** (`domain/risk/pre_trade.zig`): Sequential validation pipeline (`02-research-01.md:193`). Size limits (max shares, max notional, max % ADV), price reasonability checks (% from NBBO mid, % from last trade), message rate throttling, duplicate detection (`02-research-01.md:194-196`). Configurable limit hierarchy: board → division → desk → trader → strategy (`02-research-01.md:199`). Utilization zones with breach escalation (`02-research-01.md:200-201`).
+
+**Risk calculations** (`domain/risk/`): VaR — historical, parametric (`z_alpha * sigma * sqrt(T)`), Monte Carlo with Cholesky decomposition (`02-research-01.md:174-176`). Expected Shortfall / CVaR (`02-research-01.md:177`). Options Greeks — Delta, Gamma, Vega, Theta, Rho with Black-Scholes formulas (`02-research-01.md:180-184`). Fixed income — DV01, Key Rate DV01s, CS01, Convexity (`02-research-01.md:187-190`). Stress testing with historical and hypothetical scenarios (`02-research-01.md:205-208`). Risk attribution with factor models and marginal/component VaR (`02-research-01.md:215-216`).
+
+**Market data normalization** (`domain/market_data.zig`): Symbology mapping (exchange-native, ISIN, CUSIP, FIGI) (`02-research-01.md:137`). Price scaling (integer prices with implicit decimal), timestamp normalization to UTC nanoseconds, venue identification to ISO 10383 MIC (`02-research-01.md:138`). Bar aggregation: OHLCV at configurable intervals, plus volume bars, dollar bars, tick bars (`02-research-01.md:167-168`). VWAP calculation with trade condition filtering (`02-research-01.md:169`).
+
+**Tick store** (`domain/tick_store.zig`): Custom column-oriented binary format — date-partitioned directories with per-column files (timestamp, price, quantity, side). Delta encoding on timestamps, varint encoding on integer-scaled prices. Memory-mapped reads for zero-copy queries. Time-range query support via binary search on timestamp column. **Parquet writer** (`domain/parquet_writer.zig`): Batch export to Apache Parquet format for offline analysis in Python/DuckDB/Pandas.
+
+**Execution algorithms** (`domain/algos/`): VWAP (historical volume profile, participation limits), TWAP (equal slices with randomization), POV/Participation (real-time volume tracking), Implementation Shortfall (arrival price benchmark, impact models) (`02-research-01.md:363-366`). Iceberg, Sniper/Liquidity Seeking, Dark Pool, Pairs Trading, Adaptive/Multi-Strategy (`02-research-01.md:368-372`). Algorithm parameter framework with urgency levels (`02-research-01.md:375`).
+
+**Smart order routing** (`domain/sor.zig`): Venue scoring and routing decision flow (`02-research-01.md:382`). Fee optimization (maker-taker vs inverted) (`02-research-01.md:381`). Dark pool pinging logic (`02-research-01.md:369`).
+
+**Post-trade** (`domain/post_trade/`): Trade confirmation matching (`02-research-01.md:401`). Reconciliation engine: trade, position, and cash recon with configurable tolerances and break management (`02-research-01.md:354-358`). SOD/EOD procedures: position snapshots, corporate action processing, P&L sign-off workflow (`02-research-01.md:347-351`). Allocation and average pricing (`02-research-01.md:413-414`).
+
+### Layer 4: exchanges/kraken — First Exchange Adapter
+
+Consumes all SDK layers to implement Kraken connectivity:
+
+**Spot adapter** (`exchanges/kraken/spot/`): REST client for all public and private endpoints (`02-research-01.md:21-22`). Authentication with HMAC-SHA512 signing and nonce management (`02-research-01.md:14-18`). WebSocket v2 client with token refresh (15-min validity, `02-research-01.md:39`). FIX client with SenderCompID auth and sequence number management (`02-research-01.md:45-48`). Rate limit tracking: call counter with tier-based decay (`02-research-01.md:27-29`).
+
+**Futures adapter** (`exchanges/kraken/futures/`): REST client with distinct authentication (different header names, different signature input construction, `02-research-01.md:62-64`). WebSocket with challenge-based auth (`02-research-01.md:75`). Rate limit: 500 cost units per 10 seconds (`02-research-01.md:68`). Dead man's switch support (`02-research-01.md:58`). Multi-collateral margin tracking (`02-research-01.md:78-82`).
+
+**Symbol mapping**: Spot pairs like "BTC/USD" vs futures prefixed symbols like "fi_xbtusd" (`02-research-01.md:88`).
+
+### Layer 5: trading/ — Application Layer
+
+**Strategies** (`trading/strategies/`): Algo execution orchestration consuming domain/algos. Basis trading: spot on Kraken + CME futures (`02-research-01.md:546-548`). Perpetual funding rate arbitrage (`02-research-01.md:529-530`).
+
+**Analytics** (`trading/analytics/`): TCA — IS decomposition, VWAP slippage, spread capture, fill rate (`02-research-01.md:385-388`). Performance attribution: Brinson (allocation + selection + interaction) and factor-based (`02-research-01.md:495-496`). Venue toxicity analysis via VPIN (`02-research-01.md:396`).
+
+## Open Questions
+
+(none — all design decisions resolved)

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/04-outline-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/04-outline-01.md
@@ -1,0 +1,638 @@
+---
+phase: 4
+iteration: 01
+generated: 2026-04-03
+---
+
+# Outline: Trading Platform SDK (Pure Zig) with Kraken Exchange Integration
+
+Design: .claude/specs/trading-desk-kraken-integration/03-design-01.md
+
+## Overview
+
+Build a complete pure-Zig trading platform SDK in 12 vertical phases, each delivering end-to-end testable functionality. Every phase follows strict TDD: first write contract tests against public API signatures (no implementation exists yet), then implement until all tests pass with zero leaks. No external dependencies, no C interop — only `std` and code in this repo.
+
+## TDD Methodology (applies to ALL phases)
+
+Each phase has two sub-steps executed in order:
+
+### Step A: Contract Tests
+Write test files that import the module and exercise its public API. The implementation does not exist yet. Tests must cover:
+- **Happy path**: normal inputs produce correct outputs
+- **Boundary**: empty inputs, maximum values, zero quantities, smallest increments
+- **Malformed input**: truncated messages, invalid data, missing required fields, wrong types
+- **State transitions**: sequences of calls exercising stateful behavior
+- **Invariants**: properties that must ALWAYS hold (e.g., "best bid < best ask", "sequence numbers are monotonic")
+
+Rules for test code:
+1. Call the public API exactly as a consumer would — do not test internals
+2. Use `std.testing.allocator` to catch memory leaks
+3. Name tests as behavioral specifications: `"parser rejects message with missing channel field"` not `"test_parse_3"`
+4. For wire format tests, construct payloads from Kraken API docs — include doc URL as comment above each fixture
+5. No trivial tests — every test asserts something a user would care about
+
+### Step B: Implementation
+Write the module to make every test pass.
+
+Rules for implementation code:
+1. Run `zig build test` after each meaningful change — not done until all tests pass with zero leaks
+2. Do not modify test files. If a test seems wrong, flag it — do not silently change it
+3. No external dependencies. No `@cImport`. Only `std` and code in this repo
+4. Allocations must be explicit — use the allocator passed by the caller. No global state
+5. Hot-path functions must not allocate. Document any function that allocates with a comment
+
+---
+
+## Phase 1: Project Skeleton + Core Primitives
+**Delivers**: Build system (`build.zig`), module structure, memory allocators (arena/pool with 64-byte cache-line alignment), time utilities (nanosecond timestamps, format conversions), containers (SPSC ring buffer, MPSC queue, fixed-capacity hash map, sorted array), cryptography (HMAC-SHA512, SHA256, Base64, AES-128/256-GCM, ChaCha20-Poly1305, X25519, RSA-PKCS1v15, ECDSA-P256/P384)
+**Layers touched**: sdk/core (memory, time, containers, crypto), build system
+
+### Key types / signatures introduced
+```zig
+// core/memory.zig
+pub const PoolAllocator = struct {
+    pub fn init(backing: std.mem.Allocator, slot_size: usize, slot_count: usize) PoolAllocator;
+    pub fn allocator(self: *PoolAllocator) std.mem.Allocator;
+    pub fn deinit(self: *PoolAllocator) void;
+};
+pub const ArenaAllocator = struct {
+    pub fn init(backing: std.mem.Allocator) ArenaAllocator;
+    pub fn allocator(self: *ArenaAllocator) std.mem.Allocator;
+    pub fn reset(self: *ArenaAllocator) void;
+    pub fn deinit(self: *ArenaAllocator) void;
+};
+
+// core/time.zig
+pub const Timestamp = struct {
+    nanos: u128,
+    pub fn now() Timestamp;                          // CLOCK_MONOTONIC_RAW
+    pub fn wallClock() Timestamp;                    // CLOCK_REALTIME
+    pub fn toRfc3339(self: Timestamp, buf: []u8) []const u8;
+    pub fn toIso8601(self: Timestamp, buf: []u8) []const u8;
+    pub fn toFixUtc(self: Timestamp, buf: []u8) []const u8;
+    pub fn fromRfc3339(s: []const u8) !Timestamp;
+    pub fn fromUnixNanos(n: u128) Timestamp;
+};
+
+// core/containers/ring_buffer.zig
+pub fn SpscRingBuffer(comptime T: type) type {
+    return struct {
+        pub fn init(allocator: std.mem.Allocator, capacity: usize) !@This();
+        pub fn push(self: *@This(), item: T) bool;
+        pub fn pop(self: *@This()) ?T;
+        pub fn deinit(self: *@This()) void;
+    };
+}
+
+// core/containers/hash_map.zig
+pub fn FixedHashMap(comptime K: type, comptime V: type, comptime capacity: usize) type {
+    return struct {
+        pub fn init() @This();
+        pub fn put(self: *@This(), key: K, value: V) !void;
+        pub fn get(self: *@This(), key: K) ?V;
+        pub fn remove(self: *@This(), key: K) bool;
+        pub fn count(self: *@This()) usize;
+    };
+}
+
+// core/crypto/hmac.zig
+pub fn hmacSha512(key: []const u8, data: []const u8, out: *[64]u8) void;
+pub fn sha256(data: []const u8, out: *[32]u8) void;
+
+// core/crypto/base64.zig
+pub fn encode(dest: []u8, source: []const u8) []const u8;
+pub fn decode(dest: []u8, source: []const u8) ![]const u8;
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Write contract tests for all core modules — allocator behavior, timestamp conversions against known values, ring buffer push/pop/full/empty, crypto against RFC test vectors (HMAC-SHA512 RFC 4231, AES-GCM NIST vectors)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: `zig build test --summary all` shows all core test suites green
+
+---
+
+## Phase 2: I/O + TLS + HTTP + JSON (Networking Stack)
+**Delivers**: io_uring-based event loop, TCP connection management with timeouts, thread pinning via `sched_setaffinity`, TLS 1.2/1.3 client (handshake state machine, cipher suites, X.509 validation, session resumption), HTTP/1.1 client (request/response, connection pooling, chunked encoding), JSON streaming parser + DOM builder + serializer
+**Layers touched**: sdk/core/io, sdk/protocol (tls, http, json)
+**Depends on**: Phase 1
+
+### Key types / signatures introduced
+```zig
+// core/io/event_loop.zig
+pub const EventLoop = struct {
+    pub fn init(allocator: std.mem.Allocator) !EventLoop;
+    pub fn addSocket(self: *EventLoop, fd: std.posix.fd_t, handler: *const Handler) !void;
+    pub fn addTimer(self: *EventLoop, timeout_ms: u64, callback: *const fn() void) !void;
+    pub fn run(self: *EventLoop) !void;
+    pub fn deinit(self: *EventLoop) void;
+};
+
+// protocol/tls/client.zig
+pub const TlsClient = struct {
+    pub fn init(allocator: std.mem.Allocator, hostname: []const u8) !TlsClient;
+    pub fn handshake(self: *TlsClient, tcp_fd: std.posix.fd_t) !void;
+    pub fn read(self: *TlsClient, buf: []u8) !usize;
+    pub fn write(self: *TlsClient, data: []const u8) !usize;
+    pub fn close(self: *TlsClient) void;
+    pub fn deinit(self: *TlsClient) void;
+};
+
+// protocol/http/client.zig
+pub const HttpClient = struct {
+    pub fn init(allocator: std.mem.Allocator) !HttpClient;
+    pub fn get(self: *HttpClient, url: []const u8) !Response;
+    pub fn post(self: *HttpClient, url: []const u8, body: []const u8, headers: []const Header) !Response;
+    pub fn deinit(self: *HttpClient) void;
+};
+pub const Response = struct { status: u16, headers: []Header, body: []const u8 };
+
+// protocol/json.zig
+pub const JsonParser = struct {
+    pub fn init(allocator: std.mem.Allocator) JsonParser;
+    pub fn parse(self: *JsonParser, input: []const u8) !Value;
+    pub fn deinit(self: *JsonParser) void;
+};
+pub const Value = union(enum) { object: Map, array: []Value, string: []const u8, number: f64, integer: i64, boolean: bool, null_value };
+pub fn stringify(value: Value, buf: []u8) ![]const u8;
+```
+
+### Test checkpoint
+- Type: Automated + Integration
+- Step A: Contract tests for JSON (parse/stringify round-trip, malformed input, nested structures, Kraken response format), TLS (handshake state transitions, cipher negotiation), HTTP (request formatting, response parsing, chunked decoding)
+- Step B: Implement until unit tests pass; then integration test: `GET https://api.kraken.com/0/public/SystemStatus` — parse JSON response, assert `status` field exists
+- Verify: `zig build test --summary all` green + integration test fetches live Kraken data
+
+---
+
+## Phase 3: WebSocket + Kraken REST (Public + Auth + Private)
+**Delivers**: WebSocket RFC 6455 client (frame parsing, ping/pong, reconnection with Cloudflare rate limit awareness), Kraken spot REST client (all public + private endpoints), Kraken spot auth (HMAC-SHA512 signing, nonce management), Kraken futures REST client + auth (different header/signature scheme), rate limit tracking (call counter with tier-based decay for spot, cost units for futures)
+**Layers touched**: sdk/protocol/websocket, exchanges/kraken/spot, exchanges/kraken/futures
+**Depends on**: Phase 2
+
+### Key types / signatures introduced
+```zig
+// protocol/websocket/client.zig
+pub const WebSocketClient = struct {
+    pub fn init(allocator: std.mem.Allocator, url: []const u8) !WebSocketClient;
+    pub fn connect(self: *WebSocketClient) !void;
+    pub fn send(self: *WebSocketClient, data: []const u8) !void;
+    pub fn receive(self: *WebSocketClient) !Message;
+    pub fn close(self: *WebSocketClient) !void;
+    pub fn deinit(self: *WebSocketClient) void;
+};
+pub const Message = struct { opcode: Opcode, payload: []const u8 };
+
+// exchanges/kraken/spot/auth.zig
+pub const SpotAuth = struct {
+    pub fn init(api_key: []const u8, api_secret: []const u8) SpotAuth;
+    pub fn sign(self: *SpotAuth, uri_path: []const u8, nonce: u64, post_data: []const u8, out: *[88]u8) []const u8;
+};
+
+// exchanges/kraken/spot/rest_client.zig
+pub const SpotRestClient = struct {
+    pub fn init(allocator: std.mem.Allocator, auth: ?SpotAuth) !SpotRestClient;
+    pub fn systemStatus(self: *SpotRestClient) !SystemStatus;
+    pub fn assetPairs(self: *SpotRestClient, pairs: ?[]const []const u8) !AssetPairsResult;
+    pub fn addOrder(self: *SpotRestClient, order: OrderRequest) !AddOrderResult;
+    pub fn cancelOrder(self: *SpotRestClient, txid: []const u8) !CancelResult;
+    pub fn getBalance(self: *SpotRestClient) !BalanceResult;
+    pub fn deinit(self: *SpotRestClient) void;
+};
+
+// exchanges/kraken/futures/auth.zig
+pub const FuturesAuth = struct {
+    pub fn init(api_key: []const u8, api_secret: []const u8) FuturesAuth;
+    pub fn sign(self: *FuturesAuth, endpoint_path: []const u8, nonce: u64, post_data: []const u8, out: *[88]u8) []const u8;
+};
+
+// exchanges/kraken/spot/rate_limiter.zig
+pub const SpotRateLimiter = struct {
+    pub fn init(tier: Tier) SpotRateLimiter;
+    pub fn canCall(self: *SpotRateLimiter, cost: u8) bool;
+    pub fn recordCall(self: *SpotRateLimiter, cost: u8) void;
+};
+```
+
+### Test checkpoint
+- Type: Automated + Integration
+- Step A: Contract tests for WebSocket (frame encode/decode, masking, ping/pong, fragmentation), Kraken spot auth (sign against known nonce/secret/path → expected HMAC output from docs), futures auth (same with different construction), rate limiter (counter decay, tier limits, boundary at max)
+- Step B: Implement until unit tests pass; integration test: authenticated `GetBalance` on spot + `accounts` on futures
+- Verify: `zig build test --summary all` green + live API calls return valid responses
+
+---
+
+## Phase 4: Kraken WebSocket Streaming + Market Data + Order Book
+**Delivers**: Kraken spot WS v2 client (token refresh every 15 min, reconnection logic), Kraken futures WS client (challenge-based auth, 60s ping), market data normalization (symbology mapping, price scaling, timestamp normalization), L2 order book (sorted price levels, O(1) top-of-book), L3 order book (per-level order queues, O(1) order lookup), `BookView` interface, bar aggregation (OHLCV, volume bars, tick bars)
+**Layers touched**: exchanges/kraken/spot (ws_client), exchanges/kraken/futures (ws_client), sdk/domain (market_data, orderbook)
+**Depends on**: Phase 3
+
+### Key types / signatures introduced
+```zig
+// domain/orderbook.zig
+pub const L2Book = struct {
+    pub fn init(allocator: std.mem.Allocator, depth: usize) !L2Book;
+    pub fn applySnapshot(self: *L2Book, bids: []const Level, asks: []const Level) void;
+    pub fn applyUpdate(self: *L2Book, side: Side, price: i64, qty: i64) void;
+    pub fn bestBid(self: *const L2Book) ?Level;
+    pub fn bestAsk(self: *const L2Book) ?Level;
+    pub fn spread(self: *const L2Book) ?i64;
+    pub fn midPrice(self: *const L2Book) ?i64;
+    pub fn deinit(self: *L2Book) void;
+};
+pub const Level = struct { price: i64, quantity: i64 };
+
+// domain/market_data.zig
+pub const SymbolMapper = struct {
+    pub fn init(allocator: std.mem.Allocator) !SymbolMapper;
+    pub fn spotToInternal(self: *SymbolMapper, kraken_pair: []const u8) ?[]const u8;
+    pub fn futurestoInternal(self: *SymbolMapper, kraken_symbol: []const u8) ?[]const u8;
+    pub fn deinit(self: *SymbolMapper) void;
+};
+
+pub const BarAggregator = struct {
+    pub fn init(interval_ns: u128) BarAggregator;
+    pub fn onTrade(self: *BarAggregator, price: i64, qty: i64, timestamp: u128) ?Bar;
+};
+pub const Bar = struct { open: i64, high: i64, low: i64, close: i64, volume: i64, timestamp: u128 };
+
+// exchanges/kraken/spot/ws_client.zig
+pub const SpotWsClient = struct {
+    pub fn init(allocator: std.mem.Allocator, auth: ?SpotAuth) !SpotWsClient;
+    pub fn connect(self: *SpotWsClient) !void;
+    pub fn subscribe(self: *SpotWsClient, channel: Channel, pairs: []const []const u8) !void;
+    pub fn nextMessage(self: *SpotWsClient) !WsMessage;
+    pub fn deinit(self: *SpotWsClient) void;
+};
+```
+
+### Test checkpoint
+- Type: Automated + Integration
+- Step A: Contract tests for L2Book (snapshot apply, incremental updates, BBO invariant `best_bid < best_ask`, empty book edge cases, price level removal when qty=0), BarAggregator (OHLCV correctness, bar boundary rollover, single-trade bar), SymbolMapper (spot pair mapping, futures prefix mapping, unknown symbol returns null), WS message parsing (Kraken v2 book snapshot format, incremental update format — payloads from docs with URL comments)
+- Step B: Implement until unit tests pass; integration test: connect to `wss://ws.kraken.com/v2`, subscribe to `book` for BTC/USD, build L2 book, assert spread > 0
+- Verify: `zig build test --summary all` green + live order book updates streaming
+
+---
+
+## Phase 5: FIX Protocol + Kraken FIX Connectivity
+**Delivers**: FIX 4.2/4.4/5.0 SP2 tag-value codec (SOH delimiter, checksum validation, message type dispatch), FIXT 1.1 session layer (Logon/Logout, Heartbeat/TestRequest, ResendRequest/SequenceReset, PossDupFlag handling, sequence number persistence), Kraken FIX client (SenderCompID auth, nonce within 5s of server time)
+**Layers touched**: sdk/protocol/fix, exchanges/kraken/spot (fix_client)
+**Depends on**: Phase 2 (needs TCP/TLS)
+
+### Key types / signatures introduced
+```zig
+// protocol/fix/codec.zig
+pub const FixMessage = struct {
+    pub fn init(allocator: std.mem.Allocator) FixMessage;
+    pub fn setTag(self: *FixMessage, tag: u32, value: []const u8) !void;
+    pub fn getTag(self: *const FixMessage, tag: u32) ?[]const u8;
+    pub fn getMsgType(self: *const FixMessage) ?[]const u8;
+    pub fn encode(self: *const FixMessage, buf: []u8) ![]const u8;
+    pub fn deinit(self: *FixMessage) void;
+};
+pub fn decode(allocator: std.mem.Allocator, raw: []const u8) !FixMessage;
+pub fn computeChecksum(data: []const u8) u8;
+
+// protocol/fix/session.zig
+pub const FixSession = struct {
+    pub fn init(allocator: std.mem.Allocator, config: SessionConfig) !FixSession;
+    pub fn connect(self: *FixSession, host: []const u8, port: u16) !void;
+    pub fn logon(self: *FixSession) !void;
+    pub fn send(self: *FixSession, msg: *FixMessage) !void;
+    pub fn receive(self: *FixSession) !FixMessage;
+    pub fn logout(self: *FixSession) !void;
+    pub fn deinit(self: *FixSession) void;
+};
+pub const SessionConfig = struct {
+    sender_comp_id: []const u8,
+    target_comp_id: []const u8,
+    fix_version: FixVersion,
+    heartbeat_interval_s: u32,
+};
+```
+
+### Test checkpoint
+- Type: Automated + Integration
+- Step A: Contract tests for FIX codec (encode/decode round-trip, checksum computation against known messages, SOH delimiter handling, missing BeginString/BodyLength/MsgType rejection, tag extraction), FIX session (Logon message construction per Kraken docs with SenderCompID auth fields, Heartbeat/TestRequest state machine, sequence number increment, PossDupFlag on resend)
+- Step B: Implement until unit tests pass; integration test: FIX Logon/Logout with Kraken FIX endpoint
+- Verify: `zig build test --summary all` green + successful FIX session establishment
+
+---
+
+## Phase 6: OMS + Order Types + Pre-Trade Risk + Event Store
+**Delivers**: Order state machine (PendingNew→New→PartiallyFilled→Filled→Cancelled etc., plus internal states Staged/Validating/RoutePending), order types with FIX tag mappings (Market/Limit/Stop/StopLimit/TrailingStop, TIF Day/GTC/IOC/FOK/GTD, bracket/OCO/contingent), pre-trade risk pipeline (size limits, price reasonability, rate throttle, duplicate detection, configurable limit hierarchy), append-only event store (sequence numbers, nanosecond timestamps, mmap, replay)
+**Layers touched**: sdk/domain (oms, order_types, risk/pre_trade), sdk/core (event_store)
+**Depends on**: Phase 1
+
+### Key types / signatures introduced
+```zig
+// domain/oms.zig
+pub const OrderStateMachine = struct {
+    pub fn init() OrderStateMachine;
+    pub fn transition(self: *OrderStateMachine, current: OrdStatus, event: ExecType) !OrdStatus;
+    pub fn isTerminal(status: OrdStatus) bool;
+};
+pub const OrdStatus = enum { pending_new, new, partially_filled, filled, cancelled, replaced, pending_cancel, rejected, suspended, pending_replace, expired, staged, validating, route_pending };
+
+pub const OrderManager = struct {
+    pub fn init(allocator: std.mem.Allocator, risk: *PreTradeRisk, store: *EventStore) !OrderManager;
+    pub fn submitOrder(self: *OrderManager, order: Order) !OrderId;
+    pub fn cancelOrder(self: *OrderManager, id: OrderId) !void;
+    pub fn replaceOrder(self: *OrderManager, id: OrderId, new_params: OrderParams) !OrderId;
+    pub fn getOrder(self: *OrderManager, id: OrderId) ?*const Order;
+    pub fn deinit(self: *OrderManager) void;
+};
+
+// domain/risk/pre_trade.zig
+pub const PreTradeRisk = struct {
+    pub fn init(allocator: std.mem.Allocator, config: RiskConfig) !PreTradeRisk;
+    pub fn validate(self: *PreTradeRisk, order: *const Order) ValidationResult;
+    pub fn deinit(self: *PreTradeRisk) void;
+};
+pub const ValidationResult = union(enum) { passed, rejected: RejectReason };
+
+// core/event_store.zig
+pub const EventStore = struct {
+    pub fn init(allocator: std.mem.Allocator, path: []const u8) !EventStore;
+    pub fn append(self: *EventStore, event: []const u8) !u64; // returns sequence number
+    pub fn read(self: *EventStore, seq: u64) ![]const u8;
+    pub fn replay(self: *EventStore, from_seq: u64) Iterator;
+    pub fn deinit(self: *EventStore) void;
+};
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for state machine (all valid transitions, all invalid transitions rejected, terminal state detection, race conditions: fill-before-cancel, fill-before-replace), order types (FIX tag mapping correctness, bracket order parent-child invariants, OCO cancellation logic), pre-trade risk (order within limits passes, over-size rejected, price too far from reference rejected, rate throttle triggers after burst, duplicate detection), event store (append/read round-trip, sequence monotonicity invariant, replay from arbitrary sequence, gap detection)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: Full order lifecycle through validation pipeline, events persisted and replayable
+
+---
+
+## Phase 7: Kraken Order Execution End-to-End
+**Delivers**: Order placement/cancel/amend via Kraken spot REST + WS v2 + FIX, Kraken futures REST + WS, integration with OMS state machine (exchange acks drive state transitions), dead man's switch (futures `cancelallordersafter` every 15-20s), symbol translation between OMS and exchange-native formats
+**Layers touched**: exchanges/kraken/spot (execution), exchanges/kraken/futures (execution), sdk/domain (oms integration)
+**Depends on**: Phases 3, 4, 5, 6
+
+### Key types / signatures introduced
+```zig
+// exchanges/kraken/spot/executor.zig
+pub const SpotExecutor = struct {
+    pub fn init(allocator: std.mem.Allocator, rest: *SpotRestClient, ws: ?*SpotWsClient, fix: ?*FixSession, oms: *OrderManager) !SpotExecutor;
+    pub fn placeOrder(self: *SpotExecutor, order: *const Order) !ExchangeOrderId;
+    pub fn cancelOrder(self: *SpotExecutor, exchange_id: ExchangeOrderId) !void;
+    pub fn amendOrder(self: *SpotExecutor, exchange_id: ExchangeOrderId, params: AmendParams) !ExchangeOrderId;
+    pub fn deinit(self: *SpotExecutor) void;
+};
+
+// exchanges/kraken/futures/executor.zig
+pub const FuturesExecutor = struct {
+    pub fn init(allocator: std.mem.Allocator, rest: *FuturesRestClient, ws: ?*FuturesWsClient, oms: *OrderManager) !FuturesExecutor;
+    pub fn placeOrder(self: *FuturesExecutor, order: *const Order) !ExchangeOrderId;
+    pub fn cancelOrder(self: *FuturesExecutor, exchange_id: ExchangeOrderId) !void;
+    pub fn setDeadManSwitch(self: *FuturesExecutor, timeout_s: u32) !void;
+    pub fn deinit(self: *FuturesExecutor) void;
+};
+```
+
+### Test checkpoint
+- Type: Automated + Integration
+- Step A: Contract tests for executor (order submission maps OMS order → Kraken API params correctly, cancel propagates through OMS state machine, amend generates new ClOrdID, dead man's switch sends periodic heartbeat, exchange rejection drives OMS to `rejected` state, partial fill drives OMS to `partially_filled`)
+- Step B: Implement until unit tests pass; integration test: place a limit order far from market on Kraken, verify OMS state transitions to `new`, cancel it, verify transition to `cancelled`
+- Verify: `zig build test --summary all` green + full order lifecycle confirmed on live exchange
+
+---
+
+## Phase 8: Position Tracking + P&L + Risk Calculations
+**Delivers**: Position tracking keyed by (Account, Instrument, SettlementDate, Currency, LegalEntity), realized/unrealized P&L, cost basis methods (FIFO, LIFO, average cost), multi-currency with base currency conversion, VaR (historical, parametric, Monte Carlo with Cholesky), Expected Shortfall, Greeks (Delta/Gamma/Vega/Theta/Rho via Black-Scholes), stress testing (historical + hypothetical scenarios), risk attribution
+**Layers touched**: sdk/domain (positions, risk/)
+**Depends on**: Phases 6, 7
+
+### Key types / signatures introduced
+```zig
+// domain/positions.zig
+pub const PositionManager = struct {
+    pub fn init(allocator: std.mem.Allocator, config: PositionConfig) !PositionManager;
+    pub fn onFill(self: *PositionManager, fill: Fill) !void;
+    pub fn getPosition(self: *PositionManager, key: PositionKey) ?*const Position;
+    pub fn realizedPnl(self: *PositionManager, key: PositionKey) ?i64;
+    pub fn unrealizedPnl(self: *PositionManager, key: PositionKey, mark_price: i64) ?i64;
+    pub fn deinit(self: *PositionManager) void;
+};
+pub const PositionKey = struct { account: []const u8, instrument: []const u8, settlement_date: u32, currency: []const u8 };
+
+// domain/risk/var.zig
+pub fn historicalVar(returns: []const f64, confidence: f64) f64;
+pub fn parametricVar(sigma: f64, z_alpha: f64, horizon_days: f64, position_value: f64) f64;
+pub fn monteCarloVar(allocator: std.mem.Allocator, covariance: []const []const f64, weights: []const f64, simulations: u32, confidence: f64) !f64;
+
+// domain/risk/greeks.zig
+pub const BlackScholes = struct {
+    pub fn delta(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64;
+    pub fn gamma(spot: f64, strike: f64, r: f64, sigma: f64, t: f64) f64;
+    pub fn vega(spot: f64, strike: f64, r: f64, sigma: f64, t: f64) f64;
+    pub fn theta(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64;
+    pub fn price(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64;
+};
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for positions (FIFO cost basis: buy 100@10, buy 100@12, sell 150 → realized P&L is known value; flat position after equal buy/sell; multi-currency conversion), VaR (parametric VaR against textbook example, historical VaR with known sorted returns, Monte Carlo VaR within statistical tolerance of parametric for normal distribution), Greeks (Black-Scholes put-call parity invariant: `C - P = S - K*e^(-rT)`, delta of deep ITM call ≈ 1.0, at-expiry option value = intrinsic)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: All risk calculations match textbook/reference values
+
+---
+
+## Phase 9: Additional Market Data Protocols (SBE, FAST, ITCH, OUCH, PITCH)
+**Delivers**: SBE decoder (CME MDP 3.0 schema-driven, zero-copy, compile-time field offsets), FAST decoder (presence maps, stop-bit encoding, delta operators), ITCH parser (NASDAQ TotalView — Add/Execute/Cancel/Delete/Replace/Trade), OUCH encoder/decoder (Enter/Replace/Cancel Order + confirmations), PITCH parser (Cboe binary — Add/Execute/Cancel/Trade with multicast UDP)
+**Layers touched**: sdk/protocol (sbe, fast, itch, ouch, pitch)
+**Depends on**: Phase 1
+
+### Key types / signatures introduced
+```zig
+// protocol/itch.zig
+pub const ItchParser = struct {
+    pub fn init() ItchParser;
+    pub fn parse(self: *ItchParser, data: []const u8) !ItchMessage;
+};
+pub const ItchMessage = union(enum) {
+    add_order: AddOrder,
+    execute: Execute,
+    cancel: Cancel,
+    delete: Delete,
+    replace: Replace,
+    trade: Trade,
+    system_event: SystemEvent,
+};
+
+// protocol/sbe.zig
+pub const SbeDecoder = struct {
+    pub fn init(schema: []const u8) !SbeDecoder;
+    pub fn decode(self: *SbeDecoder, data: []const u8) !SbeMessage;
+};
+
+// protocol/ouch.zig
+pub const OuchEncoder = struct {
+    pub fn encodeEnterOrder(order: EnterOrder, buf: []u8) ![]const u8;
+    pub fn encodeCancelOrder(token: [14]u8, buf: []u8) ![]const u8;
+};
+pub const OuchDecoder = struct {
+    pub fn decode(data: []const u8) !OuchMessage;
+};
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for each protocol using hand-constructed binary payloads matching spec formats — ITCH Add Order (message type 'A', verify all field extraction including stock locate, timestamp, order ref, side, shares, stock, price), SBE (fixed-layout message with known field offsets), FAST (stop-bit encoded integers, presence map toggling), OUCH (encode/decode round-trip for Enter Order), PITCH (Add Order Long/Short variants)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: All protocol decoders correctly parse reference messages
+
+---
+
+## Phase 10: Execution Algorithms + Smart Order Routing
+**Delivers**: VWAP (historical volume profile, participation limits), TWAP (equal slices with randomization), POV (real-time volume tracking), Implementation Shortfall (arrival price benchmark), Iceberg, Sniper/Liquidity Seeking, SOR with venue scoring, fee optimization (maker-taker vs inverted), dark pool pinging
+**Layers touched**: sdk/domain (algos/, sor)
+**Depends on**: Phases 4, 6
+
+### Key types / signatures introduced
+```zig
+// domain/algos/twap.zig
+pub const TwapAlgo = struct {
+    pub fn init(params: TwapParams) TwapAlgo;
+    pub fn nextSlice(self: *TwapAlgo, now: u128) ?ChildOrder;
+    pub fn onFill(self: *TwapAlgo, fill: Fill) void;
+    pub fn isComplete(self: *TwapAlgo) bool;
+    pub fn remainingQty(self: *TwapAlgo) i64;
+};
+pub const TwapParams = struct { total_qty: i64, start_time: u128, end_time: u128, num_slices: u32, instrument: []const u8, side: Side };
+
+// domain/algos/vwap.zig
+pub const VwapAlgo = struct {
+    pub fn init(params: VwapParams, volume_profile: []const f64) VwapAlgo;
+    pub fn onMarketData(self: *VwapAlgo, volume: i64, now: u128) ?ChildOrder;
+    pub fn onFill(self: *VwapAlgo, fill: Fill) void;
+    pub fn participationRate(self: *const VwapAlgo) f64;
+};
+
+// domain/sor.zig
+pub const SmartOrderRouter = struct {
+    pub fn init(allocator: std.mem.Allocator, venues: []const VenueConfig) !SmartOrderRouter;
+    pub fn route(self: *SmartOrderRouter, order: *const Order, market_state: *const MarketState) !RoutingDecision;
+    pub fn deinit(self: *SmartOrderRouter) void;
+};
+pub const RoutingDecision = struct { venue: []const u8, child_orders: []ChildOrder };
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for TWAP (total quantity divided evenly across slices, randomization stays within bounds, fill tracking reduces remaining, completion detection), VWAP (participation rate never exceeds limit, volume-profile weighting correctness), SOR (routes to lowest-fee venue when prices equal, routes to best-price venue when fees equal, splits across venues for large orders)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: All algo invariants hold under varied input sequences
+
+---
+
+## Phase 11: Post-Trade + Reconciliation + Tick Store
+**Delivers**: Trade confirmation matching, reconciliation engine (trade/position/cash recon with configurable tolerances, break management), SOD/EOD procedures (position snapshots, P&L sign-off), allocation and average pricing, tick store (columnar binary — date-partitioned, delta-encoded timestamps, varint prices, mmap reads), Parquet writer (batch export)
+**Layers touched**: sdk/domain (post_trade/, tick_store, parquet_writer)
+**Depends on**: Phases 7, 8
+
+### Key types / signatures introduced
+```zig
+// domain/post_trade/reconciliation.zig
+pub const ReconEngine = struct {
+    pub fn init(allocator: std.mem.Allocator, tolerance: ReconTolerance) !ReconEngine;
+    pub fn reconcileTrades(self: *ReconEngine, internal: []const Trade, external: []const Trade) !ReconResult;
+    pub fn reconcilePositions(self: *ReconEngine, internal: []const Position, external: []const Position) !ReconResult;
+    pub fn deinit(self: *ReconEngine) void;
+};
+pub const ReconResult = struct { matched: u32, breaks: []Break };
+
+// domain/tick_store.zig
+pub const TickStore = struct {
+    pub fn init(allocator: std.mem.Allocator, base_path: []const u8) !TickStore;
+    pub fn write(self: *TickStore, instrument: []const u8, tick: Tick) !void;
+    pub fn query(self: *TickStore, instrument: []const u8, from: u128, to: u128) !TickIterator;
+    pub fn deinit(self: *TickStore) void;
+};
+
+// domain/parquet_writer.zig
+pub const ParquetWriter = struct {
+    pub fn init(allocator: std.mem.Allocator, path: []const u8, schema: Schema) !ParquetWriter;
+    pub fn writeRowGroup(self: *ParquetWriter, columns: []const Column) !void;
+    pub fn close(self: *ParquetWriter) !void;
+};
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for recon (perfect match returns zero breaks, quantity mismatch flagged, missing trade flagged, tolerance allows small price differences), tick store (write/read round-trip, time-range query returns correct subset, date partition boundary handling, empty range returns no results), Parquet (write row group and verify file header magic bytes `PAR1`, column data retrievable)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: Full EOD workflow — snapshot positions, reconcile, export ticks to Parquet
+
+---
+
+## Phase 12: Trading Strategies + Analytics
+**Delivers**: TCA (Implementation Shortfall decomposition, VWAP slippage, spread capture, fill rate), performance attribution (Brinson allocation/selection/interaction, factor-based), venue toxicity via VPIN, basis trading strategy (spot vs futures), perpetual funding rate arbitrage strategy
+**Layers touched**: trading/ (strategies, analytics)
+**Depends on**: Phases 10, 11
+
+### Key types / signatures introduced
+```zig
+// trading/analytics/tca.zig
+pub const TcaEngine = struct {
+    pub fn init(allocator: std.mem.Allocator) !TcaEngine;
+    pub fn analyze(self: *TcaEngine, executions: []const Execution, benchmark: Benchmark) !TcaReport;
+    pub fn deinit(self: *TcaEngine) void;
+};
+pub const TcaReport = struct { is_cost_bps: f64, vwap_slippage_bps: f64, spread_capture: f64, fill_rate: f64 };
+
+// trading/analytics/attribution.zig
+pub const BrinsonAttribution = struct {
+    pub fn compute(portfolio: []const Holding, benchmark: []const Holding) AttributionResult;
+};
+pub const AttributionResult = struct { allocation: f64, selection: f64, interaction: f64, total: f64 };
+
+// trading/strategies/basis.zig
+pub const BasisStrategy = struct {
+    pub fn init(allocator: std.mem.Allocator, config: BasisConfig) !BasisStrategy;
+    pub fn onMarketData(self: *BasisStrategy, spot: *const L2Book, futures: *const L2Book) ?Signal;
+    pub fn deinit(self: *BasisStrategy) void;
+};
+pub const Signal = struct { direction: Direction, spot_qty: i64, futures_qty: i64, expected_basis_bps: f64 };
+```
+
+### Test checkpoint
+- Type: Automated
+- Step A: Contract tests for TCA (IS decomposition components sum to total cost, zero-slippage when all fills at arrival price, VWAP slippage sign correctness), Brinson attribution (allocation + selection + interaction = total excess return, zero-weight sectors contribute zero allocation effect), basis strategy (generates buy-spot/sell-futures signal when basis exceeds threshold, no signal when basis within band, signal quantities maintain hedge ratio)
+- Step B: Implement until `zig build test` passes with zero leaks
+- Verify: End-to-end simulation — strategy signals → algo execution → position/P&L tracking → TCA report
+
+---
+
+## Dependencies
+
+```
+Phase 1 ─┬─→ Phase 2 ──→ Phase 3 ──→ Phase 4 ──┐
+          │                                       │
+          ├─→ Phase 2 ──→ Phase 5 ───────────────┤
+          │                                       │
+          ├─→ Phase 6 ───────────────────────────┤
+          │                                       │
+          ├─→ Phase 9 (independent)               │
+          │                                       │
+          │              Phase 7 ←────────────────┘
+          │                ↓
+          │              Phase 8
+          │                ↓
+          ├─→ Phase 4 + Phase 6 → Phase 10
+          │                          ↓
+          │              Phase 11 ←─ Phase 7 + Phase 8
+          │                ↓           ↓
+          └──────────── Phase 12 ←── Phase 10 + Phase 11
+```
+
+- Phase 5 (FIX) and Phase 6 (OMS) can run **in parallel** with Phases 3-4 after their respective prerequisites
+- Phase 9 (additional protocols) can run **anytime after Phase 1** — fully independent
+- Phase 7 is the convergence point requiring Phases 3, 4, 5, and 6
+- Phases 8-12 are sequential with limited parallelism

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/05-plan-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/05-plan-01.md
@@ -1,0 +1,1161 @@
+---
+phase: 5
+iteration: 01
+generated: 2026-04-03
+---
+
+# Implementation Plan: Trading Platform SDK (Pure Zig) with Kraken Exchange Integration
+
+Design: .claude/specs/trading-desk-kraken-integration/03-design-01.md
+Outline: .claude/specs/trading-desk-kraken-integration/04-outline-01.md
+
+---
+
+## Phase 1: Project Skeleton + Core Primitives
+
+### Overview
+Establish the build system, module structure, and foundational libraries: memory allocators (arena/pool with 64-byte cache-line alignment), time utilities (nanosecond timestamps, format conversions), containers (SPSC ring buffer, MPSC queue, fixed-capacity hash map, sorted array), and cryptography (HMAC-SHA512, SHA256, Base64, AES-128/256-GCM, ChaCha20-Poly1305, X25519, RSA-PKCS1v15, ECDSA-P256/P384).
+
+### Changes
+
+#### `build.zig` — NEW
+- Root build file for the entire project
+- Define modules: `sdk_core`, `sdk_protocol`, `sdk_domain`, `exchanges_kraken`, `trading`
+- Add test steps for each module: `zig build test` runs all, `zig build test-core` runs core only
+- Set optimization modes: `ReleaseFast` for benchmarks, `Debug` for development with safety checks
+- Configure cache-line alignment constant (64 bytes) as a build option
+
+#### `sdk/core/memory.zig` — NEW
+- `PoolAllocator`: fixed-slot allocator backed by a contiguous slab, 64-byte aligned slots
+  - `pub fn init(backing: std.mem.Allocator, slot_size: usize, slot_count: usize) PoolAllocator` — allocates slab, initializes free list
+  - `pub fn allocator(self: *PoolAllocator) std.mem.Allocator` — returns std.mem.Allocator interface wrapping pool alloc/free
+  - `pub fn deinit(self: *PoolAllocator) void` — frees backing slab
+- `ArenaAllocator`: bump allocator with reset capability
+  - `pub fn init(backing: std.mem.Allocator) ArenaAllocator` — allocates initial page
+  - `pub fn allocator(self: *ArenaAllocator) std.mem.Allocator` — returns std.mem.Allocator interface
+  - `pub fn reset(self: *ArenaAllocator) void` — resets bump pointer to start, retains pages
+  - `pub fn deinit(self: *ArenaAllocator) void` — frees all pages
+
+#### `sdk/core/time.zig` — NEW
+- `Timestamp` struct with `nanos: u128` field
+  - `pub fn now() Timestamp` — reads `CLOCK_MONOTONIC_RAW` via `std.posix.clock_gettime`
+  - `pub fn wallClock() Timestamp` — reads `CLOCK_REALTIME`
+  - `pub fn toRfc3339(self: Timestamp, buf: []u8) []const u8` — formats as `YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ`
+  - `pub fn toIso8601(self: Timestamp, buf: []u8) []const u8` — formats as `YYYYMMDD-HH:MM:SS.nnn`
+  - `pub fn toFixUtc(self: Timestamp, buf: []u8) []const u8` — formats as FIX UTCTimestamp `YYYYMMDD-HH:MM:SS.nnn`
+  - `pub fn fromRfc3339(s: []const u8) !Timestamp` — parses RFC 3339 string
+  - `pub fn fromUnixNanos(n: u128) Timestamp` — constructs from raw nanoseconds
+
+#### `sdk/core/containers/ring_buffer.zig` — NEW
+- `pub fn SpscRingBuffer(comptime T: type) type` — single-producer single-consumer lock-free ring buffer
+  - Power-of-two capacity (round up in init), atomic read/write indices
+  - `pub fn init(allocator: std.mem.Allocator, capacity: usize) !@This()` — allocates buffer, rounds capacity to next power of 2
+  - `pub fn push(self: *@This(), item: T) bool` — returns false if full (non-blocking)
+  - `pub fn pop(self: *@This()) ?T` — returns null if empty (non-blocking)
+  - `pub fn deinit(self: *@This()) void` — frees buffer
+
+#### `sdk/core/containers/mpsc_queue.zig` — NEW
+- `pub fn MpscQueue(comptime T: type) type` — multi-producer single-consumer intrusive queue
+  - Lock-free push via atomic CAS on tail pointer
+  - `pub fn init() @This()`
+  - `pub fn push(self: *@This(), node: *Node) void` — atomic push
+  - `pub fn pop(self: *@This()) ?*Node` — single-consumer pop
+  - `Node` struct with `next: ?*Node` and `data: T`
+
+#### `sdk/core/containers/hash_map.zig` — NEW
+- `pub fn FixedHashMap(comptime K: type, comptime V: type, comptime capacity: usize) type` — compile-time sized, open addressing with linear probing
+  - `pub fn init() @This()` — zero-initializes slots
+  - `pub fn put(self: *@This(), key: K, value: V) !void` — errors if full
+  - `pub fn get(self: *@This(), key: K) ?V` — returns null if not found
+  - `pub fn remove(self: *@This(), key: K) bool` — returns whether key existed
+  - `pub fn count(self: *@This()) usize`
+
+#### `sdk/core/containers/sorted_array.zig` — NEW
+- `pub fn SortedArray(comptime T: type, comptime compareFn: fn(T, T) std.math.Order) type` — fixed-capacity sorted array with binary search
+  - `pub fn init(allocator: std.mem.Allocator, capacity: usize) !@This()`
+  - `pub fn insert(self: *@This(), item: T) !void` — binary search for position, shift and insert
+  - `pub fn find(self: *@This(), item: T) ?usize` — binary search, returns index
+  - `pub fn removeAt(self: *@This(), index: usize) T`
+  - `pub fn deinit(self: *@This()) void`
+
+#### `sdk/core/crypto/hmac.zig` — NEW
+- `pub fn hmacSha512(key: []const u8, data: []const u8, out: *[64]u8) void` — HMAC-SHA-512 per RFC 2104/4231
+- `pub fn sha256(data: []const u8, out: *[32]u8) void` — SHA-256 per FIPS 180-4
+- `pub fn sha512(data: []const u8, out: *[64]u8) void` — SHA-512 per FIPS 180-4
+- Internal: implement SHA-512 compression function, message schedule, padding; HMAC wraps SHA-512 with ipad/opad
+
+#### `sdk/core/crypto/base64.zig` — NEW
+- `pub fn encode(dest: []u8, source: []const u8) []const u8` — standard Base64 encoding per RFC 4648
+- `pub fn decode(dest: []u8, source: []const u8) ![]const u8` — decodes, errors on invalid characters or padding
+- `pub fn encodedLen(source_len: usize) usize` — returns required output buffer size
+- `pub fn decodedLen(source_len: usize) usize`
+
+#### `sdk/core/crypto/aes.zig` — NEW
+- AES-128 and AES-256 key expansion and block cipher (SubBytes, ShiftRows, MixColumns, AddRoundKey)
+- `pub const AesGcm = struct` — AES-GCM authenticated encryption
+  - `pub fn encrypt(key: []const u8, nonce: *const [12]u8, plaintext: []const u8, aad: []const u8, ciphertext: []u8, tag: *[16]u8) void`
+  - `pub fn decrypt(key: []const u8, nonce: *const [12]u8, ciphertext: []const u8, aad: []const u8, tag: *const [16]u8, plaintext: []u8) !void` — errors if tag mismatch
+
+#### `sdk/core/crypto/chacha20.zig` — NEW
+- ChaCha20 stream cipher per RFC 8439
+- `pub const ChaCha20Poly1305 = struct` — AEAD construction
+  - `pub fn encrypt(key: *const [32]u8, nonce: *const [12]u8, plaintext: []const u8, aad: []const u8, ciphertext: []u8, tag: *[16]u8) void`
+  - `pub fn decrypt(key: *const [32]u8, nonce: *const [12]u8, ciphertext: []const u8, aad: []const u8, tag: *const [16]u8, plaintext: []u8) !void`
+
+#### `sdk/core/crypto/x25519.zig` — NEW
+- X25519 Diffie-Hellman key exchange per RFC 7748
+  - `pub fn keyExchange(secret_key: *const [32]u8, public_key: *const [32]u8, out: *[32]u8) void`
+  - `pub fn publicKey(secret_key: *const [32]u8) [32]u8` — derives public key from secret
+- Field arithmetic over GF(2^255-19): add, sub, mul, invert, square
+
+#### `sdk/core/crypto/rsa.zig` — NEW
+- RSA-PKCS1v15 signature verification (for X.509 certificate chain validation)
+  - `pub fn verifyPkcs1v15(public_key: RsaPublicKey, message_hash: []const u8, signature: []const u8) !void`
+  - `pub const RsaPublicKey = struct { n: BigInt, e: BigInt }`
+- Big integer arithmetic: modular exponentiation via Montgomery multiplication
+
+#### `sdk/core/crypto/ecdsa.zig` — NEW
+- ECDSA signature verification over P-256 and P-384 curves (for X.509)
+  - `pub fn verifyP256(public_key: P256Point, message_hash: *const [32]u8, sig_r: *const [32]u8, sig_s: *const [32]u8) !void`
+  - `pub fn verifyP384(public_key: P384Point, message_hash: *const [48]u8, sig_r: *const [48]u8, sig_s: *const [48]u8) !void`
+- Elliptic curve point arithmetic: add, double, scalar multiply
+
+#### `sdk/core/tests/memory_test.zig` — NEW
+- Pool allocator: allocate all slots then verify full, free one then allocate succeeds, alignment is 64 bytes
+- Arena allocator: allocate, reset, re-allocate reuses memory, deinit frees all
+- Use `std.testing.allocator` to verify zero leaks
+
+#### `sdk/core/tests/time_test.zig` — NEW
+- `now()` returns monotonically increasing values across calls
+- `toRfc3339` / `fromRfc3339` round-trip for known epoch values
+- `toIso8601` format matches expected string for known timestamp
+- `toFixUtc` format matches FIX UTCTimestamp spec
+- `fromUnixNanos(0)` produces epoch
+
+#### `sdk/core/tests/containers_test.zig` — NEW
+- Ring buffer: push until full returns false, pop until empty returns null, push/pop interleaved, capacity rounds to power of 2
+- MPSC queue: push from multiple (simulated sequential), pop order is FIFO
+- Hash map: put/get round-trip, remove returns true for existing key, put when full returns error
+- Sorted array: insert maintains sort order, find returns correct index, removeAt shifts elements
+
+#### `sdk/core/tests/crypto_test.zig` — NEW
+- HMAC-SHA512: test vectors from RFC 4231 (all 7 test cases)
+- SHA-256: test vectors from NIST FIPS 180-4 examples
+- Base64: encode/decode round-trip, known test vectors from RFC 4648
+- AES-GCM: NIST SP 800-38D test vectors
+- ChaCha20-Poly1305: RFC 8439 test vectors (Section 2.8.2)
+- X25519: RFC 7748 test vectors
+- RSA-PKCS1v15: verify a known signature
+- ECDSA-P256: verify a known NIST test vector signature
+
+### Edge cases
+- Pool allocator at capacity: `allocator()` returns `error.OutOfMemory` when all slots used
+- Ring buffer capacity 1: push then pop works, second push without pop fails
+- Hash map with hash collisions: linear probing resolves correctly (test with deliberately colliding keys)
+- Base64 with padding: 1, 2, and 3 byte inputs produce correct `=`/`==` padding
+- Timestamp near epoch boundary: `fromUnixNanos(0)` and max u128 value
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 2: I/O + TLS + HTTP + JSON (Networking Stack)
+
+### Overview
+Build io_uring-based event loop, TCP connection management, thread pinning, TLS 1.2/1.3 client (full handshake state machine, cipher suites, X.509 validation, session resumption), HTTP/1.1 client (request/response, connection pooling, chunked encoding), and JSON streaming parser + DOM builder + serializer.
+
+### Changes
+
+#### `sdk/core/io/event_loop.zig` — NEW
+- io_uring-based event loop using `std.os.linux.IoUring`
+  - `pub const EventLoop = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !EventLoop` — creates io_uring instance with 256 entries
+  - `pub fn addSocket(self: *EventLoop, fd: std.posix.fd_t, handler: *const Handler) !void` — registers fd for read readiness
+  - `pub fn addTimer(self: *EventLoop, timeout_ms: u64, callback: *const fn() void) !void` — schedules timeout via `IORING_OP_TIMEOUT`
+  - `pub fn removeSocket(self: *EventLoop, fd: std.posix.fd_t) void`
+  - `pub fn run(self: *EventLoop) !void` — runs event loop until stopped
+  - `pub fn stop(self: *EventLoop) void` — sets stop flag
+  - `pub fn deinit(self: *EventLoop) void`
+  - `pub const Handler = struct { onRead: *const fn(fd: std.posix.fd_t, data: []const u8) void, onError: *const fn(fd: std.posix.fd_t, err: anyerror) void }`
+
+#### `sdk/core/io/tcp.zig` — NEW
+- TCP connection management
+  - `pub const TcpConnection = struct`
+  - `pub fn connect(allocator: std.mem.Allocator, host: []const u8, port: u16) !TcpConnection` — resolves hostname, creates non-blocking socket, connects
+  - `pub fn read(self: *TcpConnection, buf: []u8) !usize`
+  - `pub fn write(self: *TcpConnection, data: []const u8) !usize`
+  - `pub fn close(self: *TcpConnection) void`
+  - `pub fn setNoDelay(self: *TcpConnection, enabled: bool) !void` — TCP_NODELAY
+  - `pub fn fd(self: *const TcpConnection) std.posix.fd_t`
+
+#### `sdk/core/io/thread.zig` — NEW
+- Thread pinning utilities
+  - `pub fn pinToCore(core_id: usize) !void` — calls `sched_setaffinity` to pin current thread
+  - `pub fn spawnPinned(core_id: usize, comptime func: anytype, args: anytype) !std.Thread` — spawns thread and pins to core
+
+#### `sdk/protocol/tls/client.zig` — NEW
+- Full TLS 1.2/1.3 client implementation
+  - `pub const TlsClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, hostname: []const u8) !TlsClient` — stores hostname for SNI
+  - `pub fn handshake(self: *TlsClient, tcp_fd: std.posix.fd_t) !void` — executes TLS handshake state machine:
+    1. Send ClientHello (with SNI, supported cipher suites, key shares for TLS 1.3)
+    2. Receive ServerHello, select cipher suite and version
+    3. TLS 1.2: receive Certificate, ServerKeyExchange, ServerHelloDone; send ClientKeyExchange, ChangeCipherSpec, Finished
+    4. TLS 1.3: receive EncryptedExtensions, Certificate, CertificateVerify, Finished; send Finished
+    5. Verify server certificate chain via X.509 validation (root CA store)
+  - `pub fn read(self: *TlsClient, buf: []u8) !usize` — decrypts TLS records
+  - `pub fn write(self: *TlsClient, data: []const u8) !usize` — encrypts and sends TLS records
+  - `pub fn close(self: *TlsClient) void` — sends close_notify
+  - `pub fn deinit(self: *TlsClient) void`
+
+#### `sdk/protocol/tls/x509.zig` — NEW
+- X.509 certificate parsing and chain validation
+  - `pub const Certificate = struct` — parsed X.509 fields (subject, issuer, public key, validity, extensions)
+  - `pub fn parse(allocator: std.mem.Allocator, der: []const u8) !Certificate` — DER/ASN.1 parser
+  - `pub fn verifyChain(chain: []const Certificate, root_store: *const RootStore, hostname: []const u8) !void` — validates signatures, expiry, hostname match
+  - `pub const RootStore = struct` — embedded root CA certificates (Mozilla root store subset for major CAs)
+
+#### `sdk/protocol/tls/record.zig` — NEW
+- TLS record layer: framing, content type dispatch, fragmentation/reassembly
+  - `pub fn readRecord(fd: std.posix.fd_t, buf: []u8) !Record`
+  - `pub fn writeRecord(fd: std.posix.fd_t, content_type: ContentType, data: []const u8, cipher_state: ?*CipherState) !void`
+  - `pub const Record = struct { content_type: ContentType, version: u16, payload: []const u8 }`
+
+#### `sdk/protocol/http/client.zig` — NEW
+- HTTP/1.1 client with connection pooling
+  - `pub const HttpClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !HttpClient` — initializes connection pool
+  - `pub fn get(self: *HttpClient, url: []const u8) !Response` — parses URL, manages connection, sends GET, reads response
+  - `pub fn post(self: *HttpClient, url: []const u8, body: []const u8, headers: []const Header) !Response`
+  - `pub fn deinit(self: *HttpClient) void` — closes all pooled connections
+  - `pub const Response = struct { status: u16, headers: []Header, body: []const u8 }`
+  - `pub const Header = struct { name: []const u8, value: []const u8 }`
+
+#### `sdk/protocol/http/url.zig` — NEW
+- URL parsing: scheme, host, port, path, query
+  - `pub fn parse(url: []const u8) !Url`
+  - `pub const Url = struct { scheme: []const u8, host: []const u8, port: u16, path: []const u8, query: ?[]const u8 }`
+
+#### `sdk/protocol/http/chunked.zig` — NEW
+- HTTP chunked transfer encoding decoder
+  - `pub fn decode(allocator: std.mem.Allocator, reader: anytype) ![]const u8` — reads chunk-size + data until 0-length chunk
+
+#### `sdk/protocol/json.zig` — NEW
+- Streaming JSON parser + DOM builder + serializer
+  - `pub const JsonParser = struct`
+  - `pub fn init(allocator: std.mem.Allocator) JsonParser`
+  - `pub fn parse(self: *JsonParser, input: []const u8) !Value` — tokenize + build DOM tree
+  - `pub fn deinit(self: *JsonParser) void` — frees all allocated DOM nodes
+  - `pub const Value = union(enum) { object: ObjectMap, array: []Value, string: []const u8, number: f64, integer: i64, boolean: bool, null_value }`
+  - `pub const ObjectMap = struct` — ordered key-value pairs, `get(key) ?Value`, `keys() [][]const u8`
+  - `pub fn stringify(value: Value, buf: []u8) ![]const u8` — serializes Value to JSON string
+  - `pub fn stringifyAlloc(allocator: std.mem.Allocator, value: Value) ![]const u8`
+
+#### `sdk/protocol/tests/json_test.zig` — NEW
+- Parse/stringify round-trip for objects, arrays, nested structures
+- Malformed input: trailing comma, unquoted key, truncated string, unclosed bracket — all return errors
+- Number parsing: integers, floats, negative, scientific notation, edge cases (0, -0)
+- Unicode escape sequences: `\uXXXX`, surrogate pairs
+- Kraken response format: parse `{"error":[],"result":{"status":"online"}}` and extract fields
+
+#### `sdk/protocol/tests/tls_test.zig` — NEW
+- Handshake state transitions: ClientHello → ServerHello → ... → Finished
+- Cipher suite negotiation: prefer AES-256-GCM, fallback to ChaCha20-Poly1305
+- X.509 chain: valid chain passes, expired cert fails, hostname mismatch fails, self-signed rejected
+- Record layer: frame/deframe round-trip, fragment reassembly
+
+#### `sdk/protocol/tests/http_test.zig` — NEW
+- Request formatting: GET with headers, POST with body and Content-Length
+- Response parsing: status line, headers, body extraction
+- Chunked decoding: multiple chunks, zero-length terminator
+- URL parsing: full URL, default ports, path-only, query strings
+
+### Edge cases
+- TLS server sends unexpected alert: handle gracefully, return error with alert description
+- HTTP response with no Content-Length and no chunked encoding: read until connection close
+- JSON deeply nested (>100 levels): return `error.NestingTooDeep` to prevent stack overflow
+- HTTP connection pool exhaustion: create new connection rather than blocking
+- TLS session resumption: cache session tickets, attempt resumption on reconnect
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 3: WebSocket + Kraken REST (Public + Auth + Private)
+
+### Overview
+Build WebSocket RFC 6455 client (frame parsing, masking, ping/pong, reconnection with Cloudflare rate limit awareness), Kraken spot REST client (all public + private endpoints), Kraken spot auth (HMAC-SHA512 signing, nonce management), Kraken futures REST client + auth (different header/signature scheme), rate limit tracking.
+
+### Changes
+
+#### `sdk/protocol/websocket/client.zig` — NEW
+- WebSocket RFC 6455 client
+  - `pub const WebSocketClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, url: []const u8) !WebSocketClient` — parses ws/wss URL
+  - `pub fn connect(self: *WebSocketClient) !void` — HTTP upgrade handshake, Sec-WebSocket-Key/Accept validation
+  - `pub fn send(self: *WebSocketClient, data: []const u8) !void` — frames as text, applies client masking
+  - `pub fn sendBinary(self: *WebSocketClient, data: []const u8) !void` — frames as binary
+  - `pub fn receive(self: *WebSocketClient) !Message` — reads and deframes, handles control frames internally
+  - `pub fn close(self: *WebSocketClient) !void` — sends close frame, waits for close response
+  - `pub fn deinit(self: *WebSocketClient) void`
+  - `pub const Message = struct { opcode: Opcode, payload: []const u8 }`
+  - `pub const Opcode = enum(u4) { continuation, text, binary, close = 8, ping, pong }`
+
+#### `sdk/protocol/websocket/frame.zig` — NEW
+- WebSocket frame encoding/decoding
+  - `pub fn encodeFrame(buf: []u8, opcode: Opcode, payload: []const u8, mask: bool) ![]const u8` — writes FIN, opcode, length (7/16/64-bit), mask key, masked payload
+  - `pub fn decodeFrame(data: []const u8) !Frame` — parses header, validates, extracts payload
+  - `pub const Frame = struct { fin: bool, opcode: Opcode, payload: []const u8, mask_key: ?[4]u8 }`
+
+#### `exchanges/kraken/spot/auth.zig` — NEW
+- Kraken spot API authentication
+  - `pub const SpotAuth = struct`
+  - `pub fn init(api_key: []const u8, api_secret: []const u8) SpotAuth` — base64-decodes api_secret, stores both
+  - `pub fn sign(self: *SpotAuth, uri_path: []const u8, nonce: u64, post_data: []const u8, out: *[88]u8) []const u8` — computes: SHA256(nonce + post_data), then HMAC-SHA512(base64_decode(secret), uri_path + sha256_hash), base64-encodes result
+  - `pub fn nextNonce() u64` — returns monotonically increasing nonce based on microsecond timestamp
+
+#### `exchanges/kraken/spot/rest_client.zig` — NEW
+- Kraken spot REST client (all public + private endpoints)
+  - `pub const SpotRestClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, auth: ?SpotAuth) !SpotRestClient` — creates HttpClient
+  - Public endpoints:
+    - `pub fn systemStatus(self: *SpotRestClient) !SystemStatus`
+    - `pub fn serverTime(self: *SpotRestClient) !ServerTime`
+    - `pub fn assetPairs(self: *SpotRestClient, pairs: ?[]const []const u8) !AssetPairsResult`
+    - `pub fn ticker(self: *SpotRestClient, pairs: []const []const u8) !TickerResult`
+    - `pub fn ohlc(self: *SpotRestClient, pair: []const u8, interval: u32) !OhlcResult`
+    - `pub fn orderBook(self: *SpotRestClient, pair: []const u8, count: ?u16) !OrderBookResult`
+  - Private endpoints (require auth):
+    - `pub fn getBalance(self: *SpotRestClient) !BalanceResult`
+    - `pub fn tradeBalance(self: *SpotRestClient, asset: ?[]const u8) !TradeBalanceResult`
+    - `pub fn openOrders(self: *SpotRestClient) !OpenOrdersResult`
+    - `pub fn closedOrders(self: *SpotRestClient) !ClosedOrdersResult`
+    - `pub fn addOrder(self: *SpotRestClient, order: OrderRequest) !AddOrderResult`
+    - `pub fn cancelOrder(self: *SpotRestClient, txid: []const u8) !CancelResult`
+    - `pub fn cancelAll(self: *SpotRestClient) !CancelAllResult`
+  - `pub fn deinit(self: *SpotRestClient) void`
+  - All methods parse JSON response, check `error` array, return typed result or error
+
+#### `exchanges/kraken/spot/types.zig` — NEW
+- Kraken spot API request/response types
+  - `SystemStatus`, `ServerTime`, `AssetPairsResult`, `TickerResult`, `OhlcResult`, `OrderBookResult`
+  - `BalanceResult`, `TradeBalanceResult`, `OpenOrdersResult`, `ClosedOrdersResult`
+  - `OrderRequest` (pair, type, ordertype, price, volume, leverage, oflags, etc.)
+  - `AddOrderResult`, `CancelResult`, `CancelAllResult`
+
+#### `exchanges/kraken/spot/rate_limiter.zig` — NEW
+- Kraken spot rate limiter (call counter with tier-based decay)
+  - `pub const SpotRateLimiter = struct`
+  - `pub fn init(tier: Tier) SpotRateLimiter` — sets max counter and decay rate per tier
+  - `pub fn canCall(self: *SpotRateLimiter, cost: u8) bool` — checks if counter + cost <= max
+  - `pub fn recordCall(self: *SpotRateLimiter, cost: u8) void` — increments counter
+  - `pub fn decay(self: *SpotRateLimiter, elapsed_seconds: f64) void` — decrements counter by decay_rate * elapsed
+  - `pub const Tier = enum { starter, intermediate, pro }`
+
+#### `exchanges/kraken/futures/auth.zig` — NEW
+- Kraken futures API authentication (different scheme from spot)
+  - `pub const FuturesAuth = struct`
+  - `pub fn init(api_key: []const u8, api_secret: []const u8) FuturesAuth`
+  - `pub fn sign(self: *FuturesAuth, endpoint_path: []const u8, nonce: u64, post_data: []const u8, out: *[88]u8) []const u8` — computes: SHA256(post_data + nonce + endpoint_path), then HMAC-SHA512(base64_decode(secret), sha256_hash), base64-encodes result
+  - Headers: `APIKey`, `Nonce`, `Authent`
+
+#### `exchanges/kraken/futures/rest_client.zig` — NEW
+- Kraken futures REST client
+  - `pub const FuturesRestClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, auth: ?FuturesAuth) !FuturesRestClient`
+  - `pub fn instruments(self: *FuturesRestClient) !InstrumentsResult`
+  - `pub fn tickers(self: *FuturesRestClient) !TickersResult`
+  - `pub fn orderbook(self: *FuturesRestClient, symbol: []const u8) !FuturesOrderBookResult`
+  - `pub fn accounts(self: *FuturesRestClient) !AccountsResult`
+  - `pub fn sendOrder(self: *FuturesRestClient, order: FuturesOrderRequest) !SendOrderResult`
+  - `pub fn cancelOrder(self: *FuturesRestClient, order_id: []const u8) !FuturesCancelResult`
+  - `pub fn cancelAllOrders(self: *FuturesRestClient, symbol: ?[]const u8) !FuturesCancelAllResult`
+  - `pub fn cancelAllOrdersAfter(self: *FuturesRestClient, timeout_seconds: u32) !DeadManResult` — dead man's switch
+  - `pub fn deinit(self: *FuturesRestClient) void`
+
+#### `exchanges/kraken/futures/types.zig` — NEW
+- Kraken futures API request/response types
+  - `InstrumentsResult`, `TickersResult`, `FuturesOrderBookResult`, `AccountsResult`
+  - `FuturesOrderRequest`, `SendOrderResult`, `FuturesCancelResult`
+
+#### `exchanges/kraken/futures/rate_limiter.zig` — NEW
+- Kraken futures rate limiter (cost-unit based)
+  - `pub const FuturesRateLimiter = struct`
+  - `pub fn init() FuturesRateLimiter`
+  - `pub fn canCall(self: *FuturesRateLimiter, cost: u8) bool`
+  - `pub fn recordCall(self: *FuturesRateLimiter, cost: u8) void`
+
+#### Test files — NEW
+- `exchanges/kraken/spot/tests/auth_test.zig` — sign against known nonce/secret/path, verify HMAC output matches expected Base64
+- `exchanges/kraken/spot/tests/rest_client_test.zig` — JSON response parsing for each endpoint, error array handling
+- `exchanges/kraken/spot/tests/rate_limiter_test.zig` — counter increment, decay, tier limits, boundary at max
+- `exchanges/kraken/futures/tests/auth_test.zig` — futures sign against known values
+- `sdk/protocol/websocket/tests/frame_test.zig` — frame encode/decode round-trip, masking, ping/pong, fragmentation, 16-bit and 64-bit length payloads
+
+### Edge cases
+- Kraken API returns non-empty error array with partial result: treat as error, include error messages
+- WebSocket ping received during message read: respond with pong automatically, continue reading
+- Rate limiter at exact boundary: `canCall` with cost that would exceed by 1 returns false
+- Nonce replay: ensure monotonicity even across rapid successive calls (microsecond resolution + counter fallback)
+- WebSocket close during send: detect broken pipe, set disconnected state
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 4: Kraken WebSocket Streaming + Market Data + Order Book
+
+### Overview
+Build Kraken spot WS v2 client (token refresh, reconnection), Kraken futures WS client (challenge-based auth, 60s ping), market data normalization (symbology, price scaling, timestamps), L2 order book (sorted price levels, O(1) top-of-book), L3 order book (per-level order queues), BookView interface, bar aggregation (OHLCV, volume bars, tick bars).
+
+### Changes
+
+#### `exchanges/kraken/spot/ws_client.zig` — NEW
+- Kraken spot WebSocket v2 client
+  - `pub const SpotWsClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, auth: ?SpotAuth) !SpotWsClient`
+  - `pub fn connect(self: *SpotWsClient) !void` — connects to `wss://ws.kraken.com/v2`, if auth provided fetches WS token via REST `GetWebSocketsToken`
+  - `pub fn subscribe(self: *SpotWsClient, channel: Channel, pairs: []const []const u8) !void` — sends subscribe JSON message per v2 format
+  - `pub fn unsubscribe(self: *SpotWsClient, channel: Channel, pairs: []const []const u8) !void`
+  - `pub fn nextMessage(self: *SpotWsClient) !WsMessage` — reads, parses JSON, returns typed message
+  - `pub fn refreshToken(self: *SpotWsClient) !void` — refreshes WS auth token (call every 15 min)
+  - `pub fn deinit(self: *SpotWsClient) void`
+  - `pub const Channel = enum { book, ticker, trade, ohlc, spread }`
+  - `pub const WsMessage = union(enum) { book_snapshot: BookSnapshot, book_update: BookUpdate, trade: TradeMsg, ticker: TickerMsg, heartbeat, system_status: SystemStatusMsg }`
+
+#### `exchanges/kraken/futures/ws_client.zig` — NEW
+- Kraken futures WebSocket client
+  - `pub const FuturesWsClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, auth: ?FuturesAuth) !FuturesWsClient`
+  - `pub fn connect(self: *FuturesWsClient) !void` — connects to `wss://futures.kraken.com/ws/v1`
+  - `pub fn authenticate(self: *FuturesWsClient) !void` — challenge-response auth: receive challenge, sign with API secret, send signed_challenge
+  - `pub fn subscribe(self: *FuturesWsClient, feed: Feed, products: ?[]const []const u8) !void`
+  - `pub fn nextMessage(self: *FuturesWsClient) !FuturesWsMessage`
+  - `pub fn deinit(self: *FuturesWsClient) void`
+  - Sends ping every 60s to maintain connection
+
+#### `sdk/domain/market_data.zig` — NEW
+- Market data normalization
+  - `pub const SymbolMapper = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !SymbolMapper`
+  - `pub fn spotToInternal(self: *SymbolMapper, kraken_pair: []const u8) ?[]const u8` — maps e.g. "XBT/USD" → "BTC-USD"
+  - `pub fn futurestoInternal(self: *SymbolMapper, kraken_symbol: []const u8) ?[]const u8` — maps e.g. "PI_XBTUSD" → "BTC-USD-PERP"
+  - `pub fn internalToSpot(self: *SymbolMapper, internal: []const u8) ?[]const u8` — reverse mapping
+  - `pub fn internalToFutures(self: *SymbolMapper, internal: []const u8) ?[]const u8`
+  - `pub fn deinit(self: *SymbolMapper) void`
+
+#### `sdk/domain/orderbook.zig` — NEW
+- L2 order book (market-by-price)
+  - `pub const L2Book = struct`
+  - `pub fn init(allocator: std.mem.Allocator, depth: usize) !L2Book` — pre-allocates sorted arrays for bids/asks
+  - `pub fn applySnapshot(self: *L2Book, bids: []const Level, asks: []const Level) void` — replaces entire book
+  - `pub fn applyUpdate(self: *L2Book, side: Side, price: i64, qty: i64) void` — qty=0 removes level, otherwise upserts
+  - `pub fn bestBid(self: *const L2Book) ?Level` — O(1) top of sorted bids
+  - `pub fn bestAsk(self: *const L2Book) ?Level` — O(1) top of sorted asks
+  - `pub fn spread(self: *const L2Book) ?i64` — bestAsk.price - bestBid.price
+  - `pub fn midPrice(self: *const L2Book) ?i64` — (bestBid.price + bestAsk.price) / 2
+  - `pub fn bids(self: *const L2Book) []const Level` — all bid levels sorted descending by price
+  - `pub fn asks(self: *const L2Book) []const Level` — all ask levels sorted ascending by price
+  - `pub fn deinit(self: *L2Book) void`
+  - `pub const Level = struct { price: i64, quantity: i64 }` — prices in fixed-point (satoshis/cents)
+  - `pub const Side = enum { bid, ask }`
+
+#### `sdk/domain/orderbook_l3.zig` — NEW
+- L3 order book (market-by-order)
+  - `pub const L3Book = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !L3Book`
+  - `pub fn addOrder(self: *L3Book, order_id: u64, side: Side, price: i64, qty: i64) !void`
+  - `pub fn modifyOrder(self: *L3Book, order_id: u64, new_qty: i64) !void`
+  - `pub fn deleteOrder(self: *L3Book, order_id: u64) !void`
+  - `pub fn getOrder(self: *const L3Book, order_id: u64) ?OrderInfo` — O(1) via hash map
+  - `pub fn bestBid(self: *const L3Book) ?Level`
+  - `pub fn bestAsk(self: *const L3Book) ?Level`
+  - `pub fn deinit(self: *L3Book) void`
+
+#### `sdk/domain/bar_aggregator.zig` — NEW
+- Bar/candle aggregation
+  - `pub const BarAggregator = struct`
+  - `pub fn init(interval_ns: u128) BarAggregator` — time-based bars
+  - `pub fn onTrade(self: *BarAggregator, price: i64, qty: i64, timestamp: u128) ?Bar` — returns completed bar when interval boundary crossed
+  - `pub const Bar = struct { open: i64, high: i64, low: i64, close: i64, volume: i64, timestamp: u128 }`
+  - `pub const VolumeBarAggregator = struct` — emits bar when accumulated volume reaches threshold
+  - `pub const TickBarAggregator = struct` — emits bar every N trades
+
+#### Test files — NEW
+- `sdk/domain/tests/orderbook_test.zig` — snapshot apply, incremental updates, BBO invariant (best_bid < best_ask), qty=0 removes level, empty book returns null for BBO, price level sorting
+- `sdk/domain/tests/bar_aggregator_test.zig` — OHLCV correctness, bar boundary rollover, single-trade bar, volume bar threshold
+- `sdk/domain/tests/market_data_test.zig` — spot pair mapping, futures symbol mapping, unknown symbol returns null, round-trip internal↔exchange
+- `exchanges/kraken/spot/tests/ws_client_test.zig` — v2 subscribe message format, book snapshot JSON parsing, book update JSON parsing, heartbeat handling
+- `exchanges/kraken/futures/tests/ws_client_test.zig` — challenge-response auth flow, feed message parsing
+
+### Edge cases
+- Book update for non-existent price level with qty > 0: insert new level
+- Book update with qty = 0 for non-existent level: no-op (don't error)
+- Symbol mapper with unknown pair: returns null, caller decides how to handle
+- BarAggregator receives out-of-order timestamps: use latest timestamp for bar boundary, don't rewind
+- WS token expiry during active session: detect 401-like error, auto-refresh token and resubscribe
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 5: FIX Protocol + Kraken FIX Connectivity
+
+### Overview
+Build FIX 4.2/4.4/5.0 SP2 tag-value codec (SOH delimiter, checksum validation, message type dispatch), FIXT 1.1 session layer (Logon/Logout, Heartbeat/TestRequest, ResendRequest/SequenceReset, PossDupFlag handling, sequence number persistence), Kraken FIX client (SenderCompID auth, nonce within 5s of server time).
+
+### Changes
+
+#### `sdk/protocol/fix/codec.zig` — NEW
+- FIX tag-value message codec
+  - `pub const FixMessage = struct`
+  - `pub fn init(allocator: std.mem.Allocator) FixMessage` — allocates tag storage
+  - `pub fn setTag(self: *FixMessage, tag: u32, value: []const u8) !void` — stores tag=value pair
+  - `pub fn getTag(self: *const FixMessage, tag: u32) ?[]const u8` — retrieves value by tag number
+  - `pub fn getMsgType(self: *const FixMessage) ?[]const u8` — shorthand for tag 35
+  - `pub fn getInt(self: *const FixMessage, tag: u32) ?i64` — parses tag value as integer
+  - `pub fn encode(self: *const FixMessage, buf: []u8) ![]const u8` — serializes: BeginString(8), BodyLength(9), MsgType(35), ...remaining tags..., CheckSum(10); SOH delimited
+  - `pub fn deinit(self: *FixMessage) void`
+  - `pub fn decode(allocator: std.mem.Allocator, raw: []const u8) !FixMessage` — parses SOH-delimited tag=value pairs, validates checksum
+  - `pub fn computeChecksum(data: []const u8) u8` — sum of all bytes mod 256
+
+#### `sdk/protocol/fix/session.zig` — NEW
+- FIX session layer (FIXT 1.1 compatible)
+  - `pub const FixSession = struct`
+  - `pub fn init(allocator: std.mem.Allocator, config: SessionConfig) !FixSession` — initializes sequence numbers to 1
+  - `pub fn connect(self: *FixSession, host: []const u8, port: u16) !void` — TCP + TLS connect
+  - `pub fn logon(self: *FixSession) !void` — sends Logon(A) with HeartBtInt, EncryptMethod=0; waits for Logon response
+  - `pub fn send(self: *FixSession, msg: *FixMessage) !void` — sets MsgSeqNum(34), SendingTime(52), SenderCompID(49), TargetCompID(56); encodes and sends
+  - `pub fn receive(self: *FixSession) !FixMessage` — reads, decodes, handles admin messages internally:
+    - Heartbeat(0): resets heartbeat timer
+    - TestRequest(1): responds with Heartbeat containing TestReqID
+    - ResendRequest(2): resends messages from sequence store
+    - SequenceReset(4): adjusts expected sequence number
+    - Logout(5): responds with Logout, marks session ended
+  - `pub fn logout(self: *FixSession) !void` — sends Logout, waits for response
+  - `pub fn deinit(self: *FixSession) void`
+  - `pub const SessionConfig = struct { sender_comp_id: []const u8, target_comp_id: []const u8, fix_version: FixVersion, heartbeat_interval_s: u32 }`
+  - `pub const FixVersion = enum { fix42, fix44, fix50sp2 }`
+
+#### `sdk/protocol/fix/seq_store.zig` — NEW
+- Sequence number persistence for gap fill / resend
+  - `pub const SeqStore = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !SeqStore`
+  - `pub fn store(self: *SeqStore, seq_num: u32, msg: []const u8) !void`
+  - `pub fn retrieve(self: *SeqStore, seq_num: u32) ?[]const u8`
+  - `pub fn lastSeqNum(self: *const SeqStore) u32`
+  - `pub fn deinit(self: *SeqStore) void`
+
+#### `exchanges/kraken/spot/fix_client.zig` — NEW
+- Kraken-specific FIX client
+  - `pub const KrakenFixClient = struct`
+  - `pub fn init(allocator: std.mem.Allocator, api_key: []const u8, api_secret: []const u8) !KrakenFixClient`
+  - `pub fn connect(self: *KrakenFixClient) !void` — connects to Kraken FIX endpoint
+  - `pub fn logon(self: *KrakenFixClient) !void` — Kraken Logon: SenderCompID = API key, Password(554) = HMAC-SHA512 sign of (SendingTime nonce), nonce must be within 5s of Kraken server time
+  - `pub fn newOrderSingle(self: *KrakenFixClient, order: FixOrderRequest) !void` — tag 35=D
+  - `pub fn orderCancelRequest(self: *KrakenFixClient, orig_cl_ord_id: []const u8, cl_ord_id: []const u8) !void` — tag 35=F
+  - `pub fn orderCancelReplaceRequest(self: *KrakenFixClient, request: FixAmendRequest) !void` — tag 35=G
+  - `pub fn nextMessage(self: *KrakenFixClient) !FixMessage` — reads next message from session
+  - `pub fn logout(self: *KrakenFixClient) !void`
+  - `pub fn deinit(self: *KrakenFixClient) void`
+
+#### Test files — NEW
+- `sdk/protocol/fix/tests/codec_test.zig` — encode/decode round-trip, checksum computation against known messages, SOH delimiter handling, missing BeginString rejection, tag extraction by number
+- `sdk/protocol/fix/tests/session_test.zig` — Logon message construction, Heartbeat/TestRequest state machine, sequence number increment, PossDupFlag on resend, Logout handshake
+- `exchanges/kraken/spot/tests/fix_client_test.zig` — Kraken Logon with SenderCompID auth fields, nonce within time window
+
+### Edge cases
+- FIX message with duplicate tags: last value wins (per FIX spec for most tags)
+- Sequence number gap detected: send ResendRequest for missing range
+- Heartbeat timeout: if no message received within 2x HeartBtInt, send TestRequest; if no response, disconnect
+- Kraken server time drift > 5s from local: sync time before Logon nonce construction
+- Checksum mismatch on received message: disconnect and log error
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 6: OMS + Order Types + Pre-Trade Risk + Event Store
+
+### Overview
+Build order state machine (full lifecycle including internal states), order types with FIX tag mappings, pre-trade risk pipeline (size limits, price reasonability, rate throttle, duplicate detection), append-only event store (sequence numbers, nanosecond timestamps, mmap, replay).
+
+### Changes
+
+#### `sdk/domain/oms.zig` — NEW
+- Order state machine and order manager
+  - `pub const OrderStateMachine = struct`
+  - `pub fn init() OrderStateMachine`
+  - `pub fn transition(self: *OrderStateMachine, current: OrdStatus, event: ExecType) !OrdStatus` — validates transition is legal, returns new state or error
+  - `pub fn isTerminal(status: OrdStatus) bool` — returns true for filled, cancelled, rejected, expired
+  - `pub const OrdStatus = enum { pending_new, new, partially_filled, filled, cancelled, replaced, pending_cancel, rejected, suspended, pending_replace, expired, staged, validating, route_pending }`
+  - `pub const ExecType = enum { new, partial_fill, fill, cancelled, replaced, rejected, pending_cancel, pending_replace, expired, suspended, restated }`
+  - `pub const OrderManager = struct`
+  - `pub fn init(allocator: std.mem.Allocator, risk: *PreTradeRisk, store: *EventStore) !OrderManager`
+  - `pub fn submitOrder(self: *OrderManager, order: Order) !OrderId` — validates via risk pipeline, transitions to pending_new, emits event, returns ID
+  - `pub fn cancelOrder(self: *OrderManager, id: OrderId) !void` — transitions to pending_cancel, emits event
+  - `pub fn replaceOrder(self: *OrderManager, id: OrderId, new_params: OrderParams) !OrderId` — transitions to pending_replace, emits event
+  - `pub fn onExecution(self: *OrderManager, id: OrderId, exec: ExecType, fill: ?FillInfo) !void` — drives state machine from exchange ack
+  - `pub fn getOrder(self: *OrderManager, id: OrderId) ?*const Order`
+  - `pub fn deinit(self: *OrderManager) void`
+  - `pub const OrderId = u64`
+  - `pub const Order = struct { id: OrderId, instrument: []const u8, side: Side, order_type: OrderType, quantity: i64, price: ?i64, tif: TimeInForce, status: OrdStatus, created_at: u128, parent_id: ?OrderId }`
+
+#### `sdk/domain/order_types.zig` — NEW
+- Order types with FIX tag mappings
+  - `pub const OrderType = enum { market, limit, stop, stop_limit, trailing_stop }`
+  - `pub const TimeInForce = enum { day, gtc, ioc, fok, gtd }`
+  - `pub fn orderTypeToFixTag(ot: OrderType) []const u8` — returns FIX OrdType(40) value: Market="1", Limit="2", Stop="3", StopLimit="4"
+  - `pub fn tifToFixTag(tif: TimeInForce) []const u8` — returns FIX TimeInForce(59) value: Day="0", GTC="1", IOC="3", FOK="4", GTD="6"
+  - `pub fn fixTagToOrderType(tag: []const u8) !OrderType` — reverse mapping
+  - `pub fn fixTagToTif(tag: []const u8) !TimeInForce`
+  - Bracket order support: `pub const BracketOrder = struct { entry: Order, take_profit: Order, stop_loss: Order }`
+  - OCO support: `pub const OcoGroup = struct { orders: [2]OrderId, fn cancelCounterpart(self: *OcoGroup, triggered: OrderId) OrderId }`
+
+#### `sdk/domain/risk/pre_trade.zig` — NEW
+- Pre-trade risk validation pipeline
+  - `pub const PreTradeRisk = struct`
+  - `pub fn init(allocator: std.mem.Allocator, config: RiskConfig) !PreTradeRisk`
+  - `pub fn validate(self: *PreTradeRisk, order: *const Order) ValidationResult` — runs pipeline sequentially:
+    1. Order validation: required fields present, quantity > 0, price > 0 for limit orders
+    2. Size limits: order qty <= max_order_size, notional <= max_notional
+    3. Price reasonability: limit price within configured % of reference price
+    4. Position limits: net position + order qty <= max_position
+    5. Rate throttle: orders per second <= max_order_rate
+    6. Duplicate detection: same instrument/side/qty/price within dedup_window_ms
+  - `pub fn deinit(self: *PreTradeRisk) void`
+  - `pub const ValidationResult = union(enum) { passed, rejected: RejectReason }`
+  - `pub const RejectReason = enum { invalid_order, size_exceeded, price_unreasonable, position_limit, rate_exceeded, duplicate_detected }`
+  - `pub const RiskConfig = struct { max_order_size: i64, max_notional: i64, max_position: i64, max_order_rate: u32, price_band_pct: f64, dedup_window_ms: u64 }`
+
+#### `sdk/core/event_store.zig` — NEW
+- Append-only event store with mmap
+  - `pub const EventStore = struct`
+  - `pub fn init(allocator: std.mem.Allocator, path: []const u8) !EventStore` — opens/creates file, mmaps for writing
+  - `pub fn append(self: *EventStore, event: []const u8) !u64` — writes length-prefixed event with sequence number and nanosecond timestamp, returns sequence number
+  - `pub fn read(self: *EventStore, seq: u64) ![]const u8` — reads event by sequence number
+  - `pub fn replay(self: *EventStore, from_seq: u64) Iterator` — returns iterator from given sequence
+  - `pub fn lastSequence(self: *const EventStore) u64`
+  - `pub fn deinit(self: *EventStore) void` — unmaps and closes file
+  - `pub const Iterator = struct { pub fn next(self: *Iterator) ?Event }`
+  - `pub const Event = struct { sequence: u64, timestamp: u128, data: []const u8 }`
+  - On-disk format per event: `[8 bytes seq][16 bytes timestamp][4 bytes data_len][data_len bytes data]`
+
+#### Test files — NEW
+- `sdk/domain/tests/oms_test.zig` — all valid state transitions, invalid transitions return error, terminal state detection, fill-before-cancel race (partial fill then cancel → partially_filled then cancelled), fill-before-replace
+- `sdk/domain/tests/order_types_test.zig` — FIX tag mapping round-trip for all order types and TIF values, bracket order parent-child invariants, OCO cancellation logic
+- `sdk/domain/tests/risk_test.zig` — order within limits passes, over-size rejected, price too far rejected, rate throttle triggers after burst, duplicate detection within window, duplicate detection outside window passes
+- `sdk/core/tests/event_store_test.zig` — append/read round-trip, sequence monotonicity, replay from arbitrary sequence, replay from seq 0 returns all events, empty store replay returns no events
+
+### Edge cases
+- State machine: cancel request for already-filled order returns error (terminal state)
+- Risk pipeline: zero-price market order skips price reasonability check
+- Event store: concurrent append (single writer assumed — document this constraint)
+- Duplicate detection: same instrument/side but different quantity is NOT a duplicate
+- Replace order: original order must be in `new` or `partially_filled` state
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 7: Kraken Order Execution End-to-End
+
+### Overview
+Wire up order placement/cancel/amend via Kraken spot REST + WS v2 + FIX, Kraken futures REST + WS, integrate with OMS state machine (exchange acks drive state transitions), implement dead man's switch for futures, symbol translation between OMS and exchange-native formats.
+
+### Changes
+
+#### `exchanges/kraken/spot/executor.zig` — NEW
+- Spot order execution engine
+  - `pub const SpotExecutor = struct`
+  - `pub fn init(allocator: std.mem.Allocator, rest: *SpotRestClient, ws: ?*SpotWsClient, fix: ?*FixSession, oms: *OrderManager) !SpotExecutor`
+  - `pub fn placeOrder(self: *SpotExecutor, order: *const Order) !ExchangeOrderId` — translates Order to Kraken format (symbol mapping, price formatting), routes via preferred channel (FIX > WS > REST), calls oms.onExecution on response
+  - `pub fn cancelOrder(self: *SpotExecutor, exchange_id: ExchangeOrderId) !void` — sends cancel via same channel as original order
+  - `pub fn amendOrder(self: *SpotExecutor, exchange_id: ExchangeOrderId, params: AmendParams) !ExchangeOrderId` — cancel-replace via FIX (tag 35=G) or cancel+new via REST/WS
+  - `pub fn processExecutionReport(self: *SpotExecutor, msg: anytype) !void` — parses exchange response, maps to ExecType, calls oms.onExecution
+  - `pub fn deinit(self: *SpotExecutor) void`
+  - `pub const ExchangeOrderId = struct { txid: [32]u8, len: u8 }`
+  - `pub const AmendParams = struct { price: ?i64, quantity: ?i64 }`
+
+#### `exchanges/kraken/futures/executor.zig` — NEW
+- Futures order execution engine
+  - `pub const FuturesExecutor = struct`
+  - `pub fn init(allocator: std.mem.Allocator, rest: *FuturesRestClient, ws: ?*FuturesWsClient, oms: *OrderManager) !FuturesExecutor`
+  - `pub fn placeOrder(self: *FuturesExecutor, order: *const Order) !ExchangeOrderId` — translates Order to futures format, sends via REST or WS
+  - `pub fn cancelOrder(self: *FuturesExecutor, exchange_id: ExchangeOrderId) !void`
+  - `pub fn setDeadManSwitch(self: *FuturesExecutor, timeout_s: u32) !void` — calls `cancelAllOrdersAfter` on futures REST, must be refreshed every 15-20s
+  - `pub fn refreshDeadManSwitch(self: *FuturesExecutor) !void` — re-sends cancelAllOrdersAfter to extend timeout
+  - `pub fn processExecutionReport(self: *FuturesExecutor, msg: anytype) !void`
+  - `pub fn deinit(self: *FuturesExecutor) void`
+
+#### `exchanges/kraken/common/symbol_translator.zig` — NEW
+- Bidirectional symbol translation between OMS internal format and Kraken exchange formats
+  - `pub const SymbolTranslator = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !SymbolTranslator`
+  - `pub fn toSpotPair(self: *SymbolTranslator, internal: []const u8) ![]const u8` — "BTC-USD" → "XXBTZUSD"
+  - `pub fn fromSpotPair(self: *SymbolTranslator, kraken: []const u8) ![]const u8` — "XXBTZUSD" → "BTC-USD"
+  - `pub fn toFuturesSymbol(self: *SymbolTranslator, internal: []const u8) ![]const u8` — "BTC-USD-PERP" → "PI_XBTUSD"
+  - `pub fn fromFuturesSymbol(self: *SymbolTranslator, kraken: []const u8) ![]const u8`
+  - `pub fn deinit(self: *SymbolTranslator) void`
+
+#### Test files — NEW
+- `exchanges/kraken/spot/tests/executor_test.zig` — order submission maps OMS order → Kraken params correctly, cancel propagates through OMS, amend generates new ClOrdID, exchange rejection drives OMS to rejected, partial fill drives OMS to partially_filled
+- `exchanges/kraken/futures/tests/executor_test.zig` — order submission, cancel, dead man's switch sends periodic refresh, exchange ack drives OMS state
+- `exchanges/kraken/common/tests/symbol_translator_test.zig` — round-trip for spot pairs, futures symbols, unknown symbol returns error
+
+### Edge cases
+- Exchange returns rejection after OMS shows pending_new: transition to rejected, no orphaned state
+- Partial fill followed by cancel: OMS shows partially_filled → cancelled (cumQty preserved)
+- Dead man's switch network failure: log warning, retry on next refresh cycle
+- Amend via REST (no native amend): atomic cancel-then-new with rollback if new order fails
+- FIX session disconnect during order: check order status via REST before retrying
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 8: Position Tracking + P&L + Risk Calculations
+
+### Overview
+Build position tracking keyed by (Account, Instrument, SettlementDate, Currency, LegalEntity), realized/unrealized P&L with cost basis methods (FIFO, LIFO, average cost), multi-currency conversion, VaR (historical, parametric, Monte Carlo), Expected Shortfall, Greeks (Black-Scholes), stress testing, risk attribution.
+
+### Changes
+
+#### `sdk/domain/positions.zig` — NEW
+- Position manager
+  - `pub const PositionManager = struct`
+  - `pub fn init(allocator: std.mem.Allocator, config: PositionConfig) !PositionManager`
+  - `pub fn onFill(self: *PositionManager, fill: Fill) !void` — updates position quantity, records lot for cost basis tracking
+  - `pub fn getPosition(self: *PositionManager, key: PositionKey) ?*const Position`
+  - `pub fn realizedPnl(self: *PositionManager, key: PositionKey) ?i64` — sum of realized P&L from closed lots
+  - `pub fn unrealizedPnl(self: *PositionManager, key: PositionKey, mark_price: i64) ?i64` — (mark_price - avg_cost) * open_qty
+  - `pub fn allPositions(self: *PositionManager) []const Position`
+  - `pub fn deinit(self: *PositionManager) void`
+  - `pub const PositionKey = struct { account: []const u8, instrument: []const u8, settlement_date: u32, currency: []const u8 }`
+  - `pub const PositionConfig = struct { cost_basis_method: CostBasisMethod, base_currency: []const u8 }`
+  - `pub const CostBasisMethod = enum { fifo, lifo, average_cost }`
+  - `pub const Position = struct { key: PositionKey, quantity: i64, avg_cost: i64, realized_pnl: i64, lots: []Lot }`
+  - `pub const Lot = struct { quantity: i64, price: i64, timestamp: u128 }`
+  - `pub const Fill = struct { instrument: []const u8, side: Side, quantity: i64, price: i64, timestamp: u128, account: []const u8, currency: []const u8 }`
+
+#### `sdk/domain/risk/var.zig` — NEW
+- Value at Risk calculations
+  - `pub fn historicalVar(returns: []const f64, confidence: f64) f64` — sorts returns, picks percentile
+  - `pub fn parametricVar(sigma: f64, z_alpha: f64, horizon_days: f64, position_value: f64) f64` — sigma * z_alpha * sqrt(horizon) * value
+  - `pub fn monteCarloVar(allocator: std.mem.Allocator, covariance: []const []const f64, weights: []const f64, simulations: u32, confidence: f64) !f64` — Cholesky decomposition of covariance matrix, generate correlated normal returns, compute portfolio loss distribution, pick percentile
+  - `pub fn expectedShortfall(returns: []const f64, confidence: f64) f64` — average of losses beyond VaR threshold
+
+#### `sdk/domain/risk/greeks.zig` — NEW
+- Black-Scholes Greeks
+  - `pub const BlackScholes = struct`
+  - `pub fn price(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64` — C = S*N(d1) - K*e^(-rT)*N(d2) for calls
+  - `pub fn delta(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64`
+  - `pub fn gamma(spot: f64, strike: f64, r: f64, sigma: f64, t: f64) f64`
+  - `pub fn vega(spot: f64, strike: f64, r: f64, sigma: f64, t: f64) f64`
+  - `pub fn theta(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64`
+  - `pub fn rho(spot: f64, strike: f64, r: f64, sigma: f64, t: f64, is_call: bool) f64`
+  - `pub fn impliedVolatility(market_price: f64, spot: f64, strike: f64, r: f64, t: f64, is_call: bool) !f64` — Newton-Raphson iteration using vega
+  - Helper: `fn normalCdf(x: f64) f64` — standard normal CDF approximation
+  - Helper: `fn normalPdf(x: f64) f64` — standard normal PDF
+
+#### `sdk/domain/risk/stress.zig` — NEW
+- Stress testing
+  - `pub const StressTest = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !StressTest`
+  - `pub fn addScenario(self: *StressTest, name: []const u8, shocks: []const Shock) !void`
+  - `pub fn run(self: *StressTest, positions: []const Position, mark_prices: []const i64) ![]StressResult`
+  - `pub fn deinit(self: *StressTest) void`
+  - `pub const Shock = struct { instrument: []const u8, price_change_pct: f64 }`
+  - `pub const StressResult = struct { scenario: []const u8, pnl_impact: f64 }`
+
+#### `sdk/domain/risk/math.zig` — NEW
+- Shared math utilities for risk calculations
+  - `pub fn choleskyDecomposition(allocator: std.mem.Allocator, matrix: []const []const f64) ![][]f64` — lower triangular decomposition
+  - `pub fn normalRandom(seed: *u64) f64` — Box-Muller transform for standard normal samples
+  - `pub fn sortAscending(data: []f64) void` — in-place sort for VaR percentile computation
+
+#### Test files — NEW
+- `sdk/domain/tests/positions_test.zig` — FIFO: buy 100@10, buy 100@12, sell 150 → realized P&L = 50*(10-10) + 100*(12-10) = known value; LIFO: same fills, different result; average cost: known result; flat position after equal buy/sell; multi-currency; unrealized P&L at mark
+- `sdk/domain/tests/var_test.zig` — parametric VaR against textbook: sigma=0.02, z=1.645, horizon=1, value=1M → known result; historical VaR with pre-sorted returns; Monte Carlo VaR within 10% of parametric for normal distribution (statistical tolerance); expected shortfall > VaR
+- `sdk/domain/tests/greeks_test.zig` — put-call parity invariant: `C - P = S - K*e^(-rT)` within 1e-10; delta of deep ITM call ≈ 1.0; at-expiry value = max(S-K, 0); vega > 0 for all non-expired options; implied vol recovery: price → impliedVol → price round-trip
+
+### Edge cases
+- Position quantity crosses zero (long → short): close all long lots, open new short lot
+- VaR with insufficient data points: return error if fewer than `1/(1-confidence)` observations
+- Greeks at expiry (t=0): delta is step function (1 or 0), gamma/vega/theta are 0
+- Implied volatility: Newton-Raphson fails to converge → return error after 100 iterations
+- Cholesky decomposition of non-positive-definite matrix: return error
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 9: Additional Market Data Protocols (SBE, FAST, ITCH, OUCH, PITCH)
+
+### Overview
+Build binary protocol parsers: SBE decoder (CME MDP 3.0, zero-copy, compile-time field offsets), FAST decoder (presence maps, stop-bit encoding, delta operators), ITCH parser (NASDAQ TotalView), OUCH encoder/decoder (Enter/Replace/Cancel), PITCH parser (Cboe binary, multicast UDP).
+
+### Changes
+
+#### `sdk/protocol/itch.zig` — NEW
+- NASDAQ ITCH 5.0 parser
+  - `pub const ItchParser = struct`
+  - `pub fn init() ItchParser`
+  - `pub fn parse(self: *ItchParser, data: []const u8) !ItchMessage` — dispatches on message type byte
+  - `pub const ItchMessage = union(enum) { system_event: SystemEvent, add_order: AddOrder, add_order_mpid: AddOrderMpid, execute: Execute, execute_price: ExecutePrice, cancel: Cancel, delete: Delete, replace: Replace, trade: Trade, cross_trade: CrossTrade, broken_trade: BrokenTrade, noii: Noii }`
+  - `pub const AddOrder = struct { timestamp: u48, order_ref: u64, side: u8, shares: u32, stock: [8]u8, price: u32 }` — fields extracted from fixed binary offsets
+  - Each message type struct with fields matching ITCH spec binary layout
+
+#### `sdk/protocol/sbe.zig` — NEW
+- Simple Binary Encoding decoder (CME MDP 3.0)
+  - `pub const SbeDecoder = struct`
+  - `pub fn init(schema: []const u8) !SbeDecoder` — parses XML schema to extract message layouts, field offsets, sizes
+  - `pub fn decode(self: *SbeDecoder, data: []const u8) !SbeMessage` — zero-copy: fields are slices into input buffer at computed offsets
+  - `pub const SbeMessage = struct { template_id: u16, fields: []Field }`
+  - `pub const Field = struct { name: []const u8, value: FieldValue }`
+  - `pub const FieldValue = union(enum) { uint8: u8, uint16: u16, uint32: u32, uint64: u64, int8: i8, int16: i16, int32: i32, int64: i64, decimal: Decimal, string: []const u8 }`
+
+#### `sdk/protocol/fast.zig` — NEW
+- FAST (FIX Adapted for Streaming) decoder
+  - `pub const FastDecoder = struct`
+  - `pub fn init(template: []const u8) !FastDecoder` — parses template XML
+  - `pub fn decode(self: *FastDecoder, data: []const u8) !FastMessage` — processes presence map, stop-bit encoded fields, delta/copy/increment operators
+  - `pub fn decodePmap(data: []const u8) !PresenceMap` — extracts presence map bits from stop-bit encoded bytes
+  - `pub fn decodeStopBit(data: []const u8) !struct { value: u64, bytes_consumed: usize }` — stop-bit integer decoding
+
+#### `sdk/protocol/ouch.zig` — NEW
+- OUCH 4.2 encoder/decoder
+  - `pub const OuchEncoder = struct`
+  - `pub fn encodeEnterOrder(order: EnterOrder, buf: []u8) ![]const u8` — message type 'O', fixed binary layout
+  - `pub fn encodeReplaceOrder(replace: ReplaceOrder, buf: []u8) ![]const u8` — message type 'U'
+  - `pub fn encodeCancelOrder(token: [14]u8, buf: []u8) ![]const u8` — message type 'X'
+  - `pub const OuchDecoder = struct`
+  - `pub fn decode(data: []const u8) !OuchMessage` — dispatches on message type byte
+  - `pub const OuchMessage = union(enum) { accepted: Accepted, replaced: Replaced, canceled: Canceled, executed: Executed, rejected: Rejected }`
+  - `pub const EnterOrder = struct { token: [14]u8, side: u8, shares: u32, symbol: [8]u8, price: u32, tif: u32, firm: [4]u8 }`
+
+#### `sdk/protocol/pitch.zig` — NEW
+- Cboe PITCH 2.x parser
+  - `pub const PitchParser = struct`
+  - `pub fn init() PitchParser`
+  - `pub fn parse(self: *PitchParser, data: []const u8) !PitchMessage`
+  - `pub const PitchMessage = union(enum) { add_order_long: AddOrderLong, add_order_short: AddOrderShort, execute: Execute, execute_at_price: ExecuteAtPrice, cancel: Cancel, trade_long: TradeLong, trade_short: TradeShort }`
+  - Each variant with fields at binary-spec offsets
+
+#### Test files — NEW
+- `sdk/protocol/tests/itch_test.zig` — hand-constructed Add Order binary payload: message type 'A' at offset 0, verify timestamp, order_ref, side, shares, stock, price extraction; each message type variant
+- `sdk/protocol/tests/sbe_test.zig` — fixed-layout message with known field offsets, verify field extraction, schema parsing
+- `sdk/protocol/tests/fast_test.zig` — stop-bit encoded integers (1-byte, 2-byte, max-length), presence map toggling, delta operator application
+- `sdk/protocol/tests/ouch_test.zig` — encode/decode round-trip for EnterOrder, ReplaceOrder, CancelOrder; verify binary layout matches spec
+- `sdk/protocol/tests/pitch_test.zig` — AddOrderLong and AddOrderShort variants, Execute, Cancel, Trade messages with known binary payloads
+
+### Edge cases
+- ITCH message with timestamp rollover at midnight: handle u48 nanosecond wrapping
+- SBE optional fields (null sentinel values): detect and return null for unset optional fields
+- FAST decoder with missing template: return error, don't crash
+- OUCH token field: exactly 14 bytes, right-padded with spaces
+- PITCH message length mismatch: validate message length field against actual data length
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 10: Execution Algorithms + Smart Order Routing
+
+### Overview
+Build VWAP (historical volume profile, participation limits), TWAP (equal slices with randomization), POV (real-time volume tracking), Implementation Shortfall (arrival price benchmark), Iceberg, Sniper/Liquidity Seeking, SOR with venue scoring, fee optimization, dark pool pinging.
+
+### Changes
+
+#### `sdk/domain/algos/twap.zig` — NEW
+- Time-Weighted Average Price algorithm
+  - `pub const TwapAlgo = struct`
+  - `pub fn init(params: TwapParams) TwapAlgo`
+  - `pub fn nextSlice(self: *TwapAlgo, now: u128) ?ChildOrder` — returns next child order if current slice time reached; applies randomization (±configured jitter %) to slice timing
+  - `pub fn onFill(self: *TwapAlgo, fill: Fill) void` — updates filled quantity
+  - `pub fn isComplete(self: *TwapAlgo) bool` — all quantity filled or past end_time
+  - `pub fn remainingQty(self: *TwapAlgo) i64`
+  - `pub const TwapParams = struct { total_qty: i64, start_time: u128, end_time: u128, num_slices: u32, instrument: []const u8, side: Side, jitter_pct: f64 }`
+  - `pub const ChildOrder = struct { instrument: []const u8, side: Side, quantity: i64, order_type: OrderType, price: ?i64 }`
+
+#### `sdk/domain/algos/vwap.zig` — NEW
+- Volume-Weighted Average Price algorithm
+  - `pub const VwapAlgo = struct`
+  - `pub fn init(params: VwapParams, volume_profile: []const f64) VwapAlgo` — volume_profile is normalized array (sums to 1.0) of expected volume per bucket
+  - `pub fn onMarketData(self: *VwapAlgo, market_volume: i64, now: u128) ?ChildOrder` — tracks market volume, computes participation, returns child order if behind schedule
+  - `pub fn onFill(self: *VwapAlgo, fill: Fill) void`
+  - `pub fn participationRate(self: *const VwapAlgo) f64` — own_volume / market_volume
+  - `pub const VwapParams = struct { total_qty: i64, start_time: u128, end_time: u128, max_participation: f64, instrument: []const u8, side: Side }`
+
+#### `sdk/domain/algos/pov.zig` — NEW
+- Percentage of Volume algorithm
+  - `pub const PovAlgo = struct`
+  - `pub fn init(params: PovParams) PovAlgo`
+  - `pub fn onMarketData(self: *PovAlgo, market_volume: i64, now: u128) ?ChildOrder` — targets configured % of market volume
+  - `pub fn onFill(self: *PovAlgo, fill: Fill) void`
+  - `pub const PovParams = struct { total_qty: i64, target_pct: f64, max_pct: f64, instrument: []const u8, side: Side }`
+
+#### `sdk/domain/algos/implementation_shortfall.zig` — NEW
+- Implementation Shortfall (arrival price benchmark)
+  - `pub const IsAlgo = struct`
+  - `pub fn init(params: IsParams, arrival_price: i64) IsAlgo`
+  - `pub fn onMarketData(self: *IsAlgo, mid_price: i64, spread: i64, volatility: f64, now: u128) ?ChildOrder` — adaptive urgency: trades faster when price moving adversely
+  - `pub fn onFill(self: *IsAlgo, fill: Fill) void`
+  - `pub fn shortfall(self: *const IsAlgo) f64` — implementation shortfall in bps vs arrival price
+
+#### `sdk/domain/algos/iceberg.zig` — NEW
+- Iceberg order algorithm
+  - `pub const IcebergAlgo = struct`
+  - `pub fn init(params: IcebergParams) IcebergAlgo`
+  - `pub fn currentSlice(self: *IcebergAlgo) ?ChildOrder` — returns visible slice
+  - `pub fn onFill(self: *IcebergAlgo, fill: Fill) ?ChildOrder` — when current slice filled, returns next slice (with optional random size variation)
+  - `pub const IcebergParams = struct { total_qty: i64, display_qty: i64, price: i64, instrument: []const u8, side: Side, variance_pct: f64 }`
+
+#### `sdk/domain/algos/sniper.zig` — NEW
+- Sniper / Liquidity Seeking algorithm
+  - `pub const SniperAlgo = struct`
+  - `pub fn init(params: SniperParams) SniperAlgo`
+  - `pub fn onBookUpdate(self: *SniperAlgo, book: *const L2Book) ?ChildOrder` — monitors book depth, fires aggressive order when sufficient liquidity appears at acceptable price
+  - `pub fn onFill(self: *SniperAlgo, fill: Fill) void`
+  - `pub const SniperParams = struct { total_qty: i64, max_price: i64, min_size_threshold: i64, instrument: []const u8, side: Side }`
+
+#### `sdk/domain/sor.zig` — NEW
+- Smart Order Router
+  - `pub const SmartOrderRouter = struct`
+  - `pub fn init(allocator: std.mem.Allocator, venues: []const VenueConfig) !SmartOrderRouter`
+  - `pub fn route(self: *SmartOrderRouter, order: *const Order, market_state: *const MarketState) !RoutingDecision` — evaluates venues by: price (best available), fees (maker-taker vs inverted), latency (historical), fill probability; returns routing decision
+  - `pub fn updateVenueStats(self: *SmartOrderRouter, venue: []const u8, stats: VenueStats) void` — updates venue scoring model
+  - `pub fn deinit(self: *SmartOrderRouter) void`
+  - `pub const VenueConfig = struct { name: []const u8, fee_model: FeeModel, priority: u8 }`
+  - `pub const FeeModel = enum { maker_taker, inverted, flat }`
+  - `pub const RoutingDecision = struct { venue: []const u8, child_orders: []ChildOrder }`
+  - `pub const MarketState = struct { books: []const struct { venue: []const u8, book: *const L2Book } }`
+  - `pub const VenueStats = struct { avg_latency_ns: u64, fill_rate: f64, reject_rate: f64 }`
+
+#### Test files — NEW
+- `sdk/domain/algos/tests/twap_test.zig` — total quantity divided evenly, randomization within jitter bounds, fill tracking reduces remaining, completion after all qty filled, completion after end_time
+- `sdk/domain/algos/tests/vwap_test.zig` — participation rate never exceeds max, volume-profile weighting correctness (high-volume bucket gets more qty), no child order when ahead of schedule
+- `sdk/domain/algos/tests/pov_test.zig` — targets configured %, caps at max_pct
+- `sdk/domain/algos/tests/iceberg_test.zig` — display qty matches configured size, refill after fill, variance within bounds, total qty tracked correctly
+- `sdk/domain/tests/sor_test.zig` — routes to lowest-fee venue when prices equal, routes to best-price venue when fees equal, splits across venues for large orders, venue with high reject rate scored lower
+
+### Edge cases
+- TWAP: remaining qty on last slice is less than slice size — send remainder as final order
+- VWAP: market volume is zero — do not divide by zero in participation calc, skip slice
+- Iceberg: fill size exceeds display qty (market order sweeps) — recalculate remaining correctly
+- SOR: all venues have same price and fee — use latency as tiebreaker
+- IS algo: price moving favorably — slow down execution to capture benefit
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 11: Post-Trade + Reconciliation + Tick Store
+
+### Overview
+Build trade confirmation matching, reconciliation engine (trade/position/cash recon with configurable tolerances, break management), SOD/EOD procedures, allocation and average pricing, tick store (columnar binary, date-partitioned, delta-encoded timestamps, varint prices, mmap reads), Parquet writer.
+
+### Changes
+
+#### `sdk/domain/post_trade/reconciliation.zig` — NEW
+- Reconciliation engine
+  - `pub const ReconEngine = struct`
+  - `pub fn init(allocator: std.mem.Allocator, tolerance: ReconTolerance) !ReconEngine`
+  - `pub fn reconcileTrades(self: *ReconEngine, internal: []const Trade, external: []const Trade) !ReconResult` — matches by trade ID or (instrument, side, qty, time window); flags mismatches
+  - `pub fn reconcilePositions(self: *ReconEngine, internal: []const Position, external: []const Position) !ReconResult` — compares quantities and values within tolerance
+  - `pub fn reconcileCash(self: *ReconEngine, internal: []const CashBalance, external: []const CashBalance) !ReconResult`
+  - `pub fn deinit(self: *ReconEngine) void`
+  - `pub const ReconTolerance = struct { price_tolerance: f64, qty_tolerance: i64, time_window_ms: u64 }`
+  - `pub const ReconResult = struct { matched: u32, breaks: []Break, unmatched_internal: u32, unmatched_external: u32 }`
+  - `pub const Break = struct { break_type: BreakType, internal: ?Trade, external: ?Trade, description: []const u8 }`
+  - `pub const BreakType = enum { quantity_mismatch, price_mismatch, missing_internal, missing_external, timing_mismatch }`
+
+#### `sdk/domain/post_trade/eod.zig` — NEW
+- SOD/EOD procedures
+  - `pub const EodProcessor = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !EodProcessor`
+  - `pub fn snapshotPositions(self: *EodProcessor, positions: *PositionManager) ![]const PositionSnapshot`
+  - `pub fn computeDailyPnl(self: *EodProcessor, positions: *PositionManager, marks: []const Mark) !DailyPnlReport`
+  - `pub fn runEndOfDay(self: *EodProcessor, positions: *PositionManager, recon: *ReconEngine, marks: []const Mark) !EodReport`
+  - `pub fn deinit(self: *EodProcessor) void`
+
+#### `sdk/domain/post_trade/allocation.zig` — NEW
+- Trade allocation and average pricing
+  - `pub fn allocateTrade(trade: Trade, accounts: []const AllocationEntry) ![]Trade` — splits a block trade across accounts pro-rata or by explicit amounts
+  - `pub fn averagePrice(fills: []const Fill) i64` — quantity-weighted average price
+  - `pub const AllocationEntry = struct { account: []const u8, ratio: f64 }`
+
+#### `sdk/domain/tick_store.zig` — NEW
+- Columnar tick store
+  - `pub const TickStore = struct`
+  - `pub fn init(allocator: std.mem.Allocator, base_path: []const u8) !TickStore` — creates directory structure
+  - `pub fn write(self: *TickStore, instrument: []const u8, tick: Tick) !void` — appends to date-partitioned file, delta-encodes timestamp, varint-encodes price
+  - `pub fn query(self: *TickStore, instrument: []const u8, from: u128, to: u128) !TickIterator` — opens relevant partition files, seeks to start time
+  - `pub fn flush(self: *TickStore) !void` — ensures all buffered writes are persisted
+  - `pub fn deinit(self: *TickStore) void`
+  - `pub const Tick = struct { timestamp: u128, price: i64, quantity: i64, side: Side }`
+  - `pub const TickIterator = struct { pub fn next(self: *TickIterator) ?Tick }`
+  - On-disk format per record: `[varint delta_timestamp][varint delta_price][varint quantity][1 byte side]`
+  - Partition naming: `{base_path}/{instrument}/YYYYMMDD.ticks`
+
+#### `sdk/domain/parquet_writer.zig` — NEW
+- Apache Parquet writer (subset of spec: uncompressed + SNAPPY, PLAIN encoding, required/optional fields)
+  - `pub const ParquetWriter = struct`
+  - `pub fn init(allocator: std.mem.Allocator, path: []const u8, schema: Schema) !ParquetWriter` — writes file header with magic bytes `PAR1`
+  - `pub fn writeRowGroup(self: *ParquetWriter, columns: []const Column) !void` — writes column chunks with page headers
+  - `pub fn close(self: *ParquetWriter) !void` — writes file footer with schema and row group metadata, writes magic bytes `PAR1` at end
+  - `pub const Schema = struct { columns: []const ColumnDef }`
+  - `pub const ColumnDef = struct { name: []const u8, type: ParquetType, repetition: Repetition }`
+  - `pub const ParquetType = enum { int32, int64, float, double, byte_array }`
+  - `pub const Column = struct { def: ColumnDef, data: []const u8 }`
+
+#### Test files — NEW
+- `sdk/domain/post_trade/tests/reconciliation_test.zig` — perfect match returns zero breaks, quantity mismatch flagged, missing trade flagged (both directions), price within tolerance matches, price outside tolerance breaks, timing mismatch
+- `sdk/domain/post_trade/tests/eod_test.zig` — position snapshot captures current state, daily P&L sums correctly, full EOD workflow runs all steps
+- `sdk/domain/post_trade/tests/allocation_test.zig` — pro-rata allocation sums to original quantity, average price is quantity-weighted
+- `sdk/domain/tests/tick_store_test.zig` — write/read round-trip, time-range query returns correct subset, date partition boundary (ticks spanning midnight), empty range returns no results, delta encoding preserves precision
+- `sdk/domain/tests/parquet_test.zig` — write row group and verify file starts with `PAR1` magic bytes, file ends with `PAR1`, column data round-trip
+
+### Edge cases
+- Reconciliation: external trade with no matching internal trade → `missing_internal` break type
+- Tick store query spanning multiple date partitions: seamlessly iterate across partition files
+- Tick store: first tick in partition has no delta (stores absolute timestamp)
+- Parquet: empty row group is valid, zero rows written → footer still correct
+- Allocation: rounding errors in pro-rata → assign remainder to last account
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`
+
+---
+
+## Phase 12: Trading Strategies + Analytics
+
+### Overview
+Build TCA (Implementation Shortfall decomposition, VWAP slippage, spread capture, fill rate), performance attribution (Brinson allocation/selection/interaction, factor-based), venue toxicity via VPIN, basis trading strategy (spot vs futures), perpetual funding rate arbitrage strategy.
+
+### Changes
+
+#### `trading/analytics/tca.zig` — NEW
+- Transaction Cost Analysis engine
+  - `pub const TcaEngine = struct`
+  - `pub fn init(allocator: std.mem.Allocator) !TcaEngine`
+  - `pub fn analyze(self: *TcaEngine, executions: []const Execution, benchmark: Benchmark) !TcaReport` — computes:
+    - Implementation Shortfall: (avg_fill - arrival_price) / arrival_price in bps, decomposed into timing cost + market impact + opportunity cost
+    - VWAP slippage: (avg_fill - market_vwap) / market_vwap in bps
+    - Spread capture: measures how much of bid-ask spread was captured vs crossed
+    - Fill rate: filled_qty / attempted_qty
+  - `pub fn deinit(self: *TcaEngine) void`
+  - `pub const Execution = struct { price: i64, quantity: i64, timestamp: u128, side: Side, venue: []const u8 }`
+  - `pub const Benchmark = struct { arrival_price: i64, market_vwap: i64, close_price: i64 }`
+  - `pub const TcaReport = struct { is_cost_bps: f64, timing_cost_bps: f64, market_impact_bps: f64, opportunity_cost_bps: f64, vwap_slippage_bps: f64, spread_capture: f64, fill_rate: f64 }`
+
+#### `trading/analytics/attribution.zig` — NEW
+- Performance attribution
+  - `pub const BrinsonAttribution = struct`
+  - `pub fn compute(portfolio: []const Holding, benchmark: []const Holding) AttributionResult` — Brinson-Fachler model:
+    - Allocation effect: sum of (w_p - w_b) * (r_b_sector - r_b_total) per sector
+    - Selection effect: sum of w_b * (r_p_sector - r_b_sector) per sector
+    - Interaction effect: sum of (w_p - w_b) * (r_p_sector - r_b_sector) per sector
+  - `pub const Holding = struct { sector: []const u8, weight: f64, return_pct: f64 }`
+  - `pub const AttributionResult = struct { allocation: f64, selection: f64, interaction: f64, total: f64 }`
+
+#### `trading/analytics/vpin.zig` — NEW
+- Volume-synchronized Probability of Informed Trading
+  - `pub const VpinCalculator = struct`
+  - `pub fn init(bucket_size: i64, num_buckets: u32) VpinCalculator`
+  - `pub fn onTrade(self: *VpinCalculator, price: i64, volume: i64, side: Side) ?f64` — returns VPIN estimate when bucket completes
+  - Classifies trades using tick rule (uptick = buy, downtick = sell)
+
+#### `trading/strategies/basis.zig` — NEW
+- Basis trading strategy (spot vs futures)
+  - `pub const BasisStrategy = struct`
+  - `pub fn init(allocator: std.mem.Allocator, config: BasisConfig) !BasisStrategy`
+  - `pub fn onMarketData(self: *BasisStrategy, spot: *const L2Book, futures: *const L2Book) ?Signal` — computes annualized basis = (futures_mid - spot_mid) / spot_mid * (365 / days_to_expiry); signals when basis exceeds entry threshold, exits when basis narrows to exit threshold
+  - `pub fn deinit(self: *BasisStrategy) void`
+  - `pub const BasisConfig = struct { entry_threshold_bps: f64, exit_threshold_bps: f64, max_position: i64, instrument_spot: []const u8, instrument_futures: []const u8, days_to_expiry: f64 }`
+  - `pub const Signal = struct { direction: Direction, spot_qty: i64, futures_qty: i64, expected_basis_bps: f64 }`
+  - `pub const Direction = enum { enter_long_basis, enter_short_basis, exit }`
+
+#### `trading/strategies/funding_arb.zig` — NEW
+- Perpetual funding rate arbitrage strategy
+  - `pub const FundingArbStrategy = struct`
+  - `pub fn init(allocator: std.mem.Allocator, config: FundingArbConfig) !FundingArbStrategy`
+  - `pub fn onFundingRate(self: *FundingArbStrategy, rate: f64, next_funding_time: u128) ?Signal` — enters when funding rate exceeds threshold (long spot + short perp when funding positive, reverse when negative)
+  - `pub fn onMarketData(self: *FundingArbStrategy, spot: *const L2Book, perp: *const L2Book) ?Signal` — monitors convergence / divergence for exit
+  - `pub fn deinit(self: *FundingArbStrategy) void`
+  - `pub const FundingArbConfig = struct { min_rate_bps: f64, max_position: i64, instrument_spot: []const u8, instrument_perp: []const u8 }`
+
+#### Test files — NEW
+- `trading/analytics/tests/tca_test.zig` — IS decomposition: timing + market_impact + opportunity = total IS cost; zero slippage when all fills at arrival price; VWAP slippage sign: buy fills above market VWAP → positive slippage; fill rate = 1.0 when all quantity filled
+- `trading/analytics/tests/attribution_test.zig` — allocation + selection + interaction = total excess return; zero-weight sectors contribute zero allocation effect; identical portfolio and benchmark → all effects zero
+- `trading/analytics/tests/vpin_test.zig` — all buys → VPIN ≈ 1.0; balanced buys/sells → VPIN ≈ 0.0; bucket rollover triggers recalculation
+- `trading/strategies/tests/basis_test.zig` — generates enter_long_basis signal when futures premium exceeds threshold; no signal when basis within band; signal quantities maintain hedge ratio (spot_qty ≈ futures_qty); exit signal when basis narrows
+- `trading/strategies/tests/funding_arb_test.zig` — positive funding rate → long spot / short perp signal; negative rate → reverse; no signal when rate below threshold
+
+### Edge cases
+- TCA: single execution (no timing cost decomposition possible) → report timing_cost = 0
+- Attribution: sector present in portfolio but not in benchmark → entire return is allocation effect
+- VPIN: exactly equal buy/sell volume → VPIN = 0.0, not NaN
+- Basis strategy: days_to_expiry approaching 0 → annualized basis becomes very large, cap at reasonable max
+- Funding arb: funding rate flips sign while positioned → exit signal
+
+### Breaking changes
+- None (greenfield)
+
+### Test checkpoint
+- command: `zig build test --summary all 2>&1`
+- expected-output: `all passed`

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/06-worktree-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/06-worktree-01.md
@@ -1,0 +1,139 @@
+---
+phase: 6
+iteration: 01
+generated: 2026-04-03
+---
+
+# Worktree Plan: Professional Trading Desk with Kraken Exchange Integration
+
+Plan: .claude/specs/trading-desk-kraken-integration/05-plan-01.md
+
+## Batch 1 (sequential prerequisite)
+
+### Worktree 1
+- Branch: trading-desk-kraken-integration-01-01
+- Path: .worktrees/trading-desk-kraken-integration-01-01
+- Phases: 1 (Project Skeleton + Core Primitives)
+- Can start: immediately
+
+## Batch 2 (after Batch 1 merges — 3 parallel)
+
+### Worktree 2
+- Branch: trading-desk-kraken-integration-02-01
+- Path: .worktrees/trading-desk-kraken-integration-02-01
+- Phases: 2 (I/O + TLS + HTTP + JSON)
+- Can start: after Batch 1 merged into main
+
+### Worktree 3
+- Branch: trading-desk-kraken-integration-02-02
+- Path: .worktrees/trading-desk-kraken-integration-02-02
+- Phases: 6 (OMS + Order Types + Pre-Trade Risk + Event Store)
+- Can start: after Batch 1 merged into main (parallel with Worktree 2, 4)
+
+### Worktree 4
+- Branch: trading-desk-kraken-integration-02-03
+- Path: .worktrees/trading-desk-kraken-integration-02-03
+- Phases: 9 (Additional Market Data Protocols — SBE, FAST, ITCH, OUCH, PITCH)
+- Can start: after Batch 1 merged into main (parallel with Worktree 2, 3)
+
+## Batch 3 (after Batch 2 merges — 3 parallel)
+
+### Worktree 5
+- Branch: trading-desk-kraken-integration-03-01
+- Path: .worktrees/trading-desk-kraken-integration-03-01
+- Phases: 3 (WebSocket + Kraken REST)
+- Can start: after Batch 2 merged into main
+
+### Worktree 6
+- Branch: trading-desk-kraken-integration-03-02
+- Path: .worktrees/trading-desk-kraken-integration-03-02
+- Phases: 5 (FIX Protocol + Kraken FIX Connectivity)
+- Can start: after Batch 2 merged into main (parallel with Worktree 5, 7)
+
+### Worktree 7
+- Branch: trading-desk-kraken-integration-03-03
+- Path: .worktrees/trading-desk-kraken-integration-03-03
+- Phases: 8 (Position Tracking + P&L + Risk Calculations)
+- Can start: after Batch 2 merged into main (parallel with Worktree 5, 6)
+
+## Batch 4 (after Batch 3 merges — 2 parallel)
+
+### Worktree 8
+- Branch: trading-desk-kraken-integration-04-01
+- Path: .worktrees/trading-desk-kraken-integration-04-01
+- Phases: 4 (Kraken WebSocket Streaming + Market Data + Order Book)
+- Can start: after Batch 3 merged into main
+
+### Worktree 9
+- Branch: trading-desk-kraken-integration-04-02
+- Path: .worktrees/trading-desk-kraken-integration-04-02
+- Phases: 11 (Post-Trade + Reconciliation + Tick Store)
+- Can start: after Batch 3 merged into main (parallel with Worktree 8)
+
+## Batch 5 (after Batch 4 merges — 3 parallel)
+
+### Worktree 10
+- Branch: trading-desk-kraken-integration-05-01
+- Path: .worktrees/trading-desk-kraken-integration-05-01
+- Phases: 7 (Kraken Order Execution End-to-End)
+- Can start: after Batch 4 merged into main
+
+### Worktree 11
+- Branch: trading-desk-kraken-integration-05-02
+- Path: .worktrees/trading-desk-kraken-integration-05-02
+- Phases: 10 (Execution Algorithms + Smart Order Routing)
+- Can start: after Batch 4 merged into main (parallel with Worktree 10, 12)
+
+### Worktree 12
+- Branch: trading-desk-kraken-integration-05-03
+- Path: .worktrees/trading-desk-kraken-integration-05-03
+- Phases: 12 (Trading Strategies + Analytics)
+- Can start: after Batch 4 merged into main (parallel with Worktree 10, 11)
+
+## Dependency analysis
+
+| Plan Phase | Worktree | Batch | Depends on Plan Phases | Files (directories) |
+|-----------|----------|-------|----------------------|---------------------|
+| 1 | 1 | 1 | None | build.zig, sdk/core/{memory,time,containers,crypto,tests} |
+| 2 | 2 | 2 | 1 | sdk/core/io, sdk/protocol/{tls,http,json} |
+| 6 | 3 | 2 | 1 | sdk/domain/{oms,order_types,risk/pre_trade}, sdk/core/event_store |
+| 9 | 4 | 2 | 1 | sdk/protocol/{itch,sbe,fast,ouch,pitch} |
+| 3 | 5 | 3 | 2 | sdk/protocol/websocket, exchanges/kraken/{spot,futures} |
+| 5 | 6 | 3 | 2 | sdk/protocol/fix, exchanges/kraken/spot/fix_client |
+| 8 | 7 | 3 | 6 | sdk/domain/{positions,risk/{var,greeks,stress,math}} |
+| 4 | 8 | 4 | 3 | exchanges/kraken/{spot,futures}/ws_client, sdk/domain/{market_data,orderbook,bar_aggregator} |
+| 11 | 9 | 4 | 8 | sdk/domain/{post_trade,tick_store,parquet_writer} |
+| 7 | 10 | 5 | 3,4,5,6 | exchanges/kraken/{spot,futures}/executor, exchanges/kraken/common |
+| 10 | 11 | 5 | 4,6 | sdk/domain/{algos,sor} |
+| 12 | 12 | 5 | 4,6 | trading/{analytics,strategies} |
+
+## Merge order
+
+1. **Batch 1**: Merge `trading-desk-kraken-integration-01-01` into main
+2. **Batch 2**: Create worktrees 2-4 from updated main. After all complete:
+   - Merge `trading-desk-kraken-integration-02-01` into main
+   - Merge `trading-desk-kraken-integration-02-02` into main
+   - Merge `trading-desk-kraken-integration-02-03` into main
+3. **Batch 3**: Create worktrees 5-7 from updated main. After all complete:
+   - Merge `trading-desk-kraken-integration-03-01` into main
+   - Merge `trading-desk-kraken-integration-03-02` into main
+   - Merge `trading-desk-kraken-integration-03-03` into main
+4. **Batch 4**: Create worktrees 8-9 from updated main. After all complete:
+   - Merge `trading-desk-kraken-integration-04-01` into main
+   - Merge `trading-desk-kraken-integration-04-02` into main
+5. **Batch 5**: Create worktrees 10-12 from updated main. After all complete:
+   - Merge `trading-desk-kraken-integration-05-01` into main
+   - Merge `trading-desk-kraken-integration-05-02` into main
+   - Merge `trading-desk-kraken-integration-05-03` into main
+
+## Notes
+
+- `build.zig` is created in Phase 1 with all module roots (`sdk_core`, `sdk_protocol`, `sdk_domain`, `exchanges_kraken`, `trading`) defined upfront. Subsequent phases add files within these module directories without modifying `build.zig`.
+- Batch 2-5 worktrees are created dynamically by Phase 7 (implementation) after each prior batch merges, ensuring they branch from the latest main.
+- No two phases within any batch modify the same files.
+
+## Implementation prompt for Phase 7
+
+```sh
+/spec.07.implement .claude/specs/trading-desk-kraken-integration/05-plan-01.md .claude/specs/trading-desk-kraken-integration/06-worktree-01.md
+```

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/07-implementation-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/07-implementation-01.md
@@ -1,0 +1,200 @@
+---
+phase: 7
+iteration: 01
+generated: 2026-04-03
+---
+
+# Implementation Log: Professional Trading Desk with Kraken Exchange Integration
+
+Plan: .claude/specs/trading-desk-kraken-integration/05-plan-01.md
+Worktrees: .claude/specs/trading-desk-kraken-integration/06-worktree-01.md
+
+## Worktree 1 — trading-desk-kraken-integration-01-01 (Batch 1)
+
+Path: .worktrees/trading-desk-kraken-integration-01-01
+Phases: 1
+
+### Phase 1: Project Skeleton + Core Primitives
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — Build Summary: 9/9 steps succeeded; 46/46 tests passed`
+- Recovery attempts: none needed
+- Details: Implemented build.zig, memory (Pool/Arena allocators), time (Timestamp with RFC3339/ISO8601/FIX), containers (SPSC ring buffer, MPSC queue, FixedHashMap, SortedArray), crypto (HMAC-SHA512, SHA-256, SHA-512, Base64, AES-GCM, ChaCha20-Poly1305, X25519, RSA-PKCS1v15, ECDSA-P256/P384). Installed Zig 0.13.0.
+- Exceptions: MpscQueue uses allocator-based init (not self-referential init() from plan). X25519 delegates to std.crypto.dh.X25519. Minor test vector corrections from plan.
+
+## Worktree 2 — trading-desk-kraken-integration-02-01 (Batch 2)
+
+Path: .worktrees/trading-desk-kraken-integration-02-01
+Phases: 2
+
+### Phase 2: I/O + TLS + HTTP + JSON
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 15/15 steps succeeded; 48/48 tests passed`
+- Recovery attempts: none needed
+- Details: Implemented io_uring event loop, TCP connection mgmt, thread pinning, TLS 1.2/1.3 client (handshake state machine, X.509 parsing, record layer), HTTP/1.1 client (connection pooling, chunked encoding, URL parsing), JSON streaming parser + DOM + serializer.
+- Exceptions: None
+
+## Worktree 3 — trading-desk-kraken-integration-02-02 (Batch 2)
+
+Path: .worktrees/trading-desk-kraken-integration-02-02
+Phases: 6
+
+### Phase 6: OMS + Order Types + Pre-Trade Risk + Event Store
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 17/17 steps succeeded; 12/12 tests passed`
+- Recovery attempts: none needed
+- Details: Implemented OrderStateMachine (full lifecycle), OrderManager (submit/cancel/replace/onExecution with risk+event injection), order types with FIX tag mappings, BracketOrder/OCO, PreTradeRisk pipeline (6 checks), append-only EventStore with binary format.
+- Exceptions: OrderManager uses anyopaque+function pointers to avoid circular deps.
+
+## Worktree 4 — trading-desk-kraken-integration-02-03 (Batch 2)
+
+Path: .worktrees/trading-desk-kraken-integration-02-03
+Phases: 9
+
+### Phase 9: Additional Market Data Protocols (SBE, FAST, ITCH, OUCH, PITCH)
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 19/19 steps succeeded; 101/101 tests passed`
+- Recovery attempts: none needed
+- Details: Implemented ITCH 5.0 parser (11 message types), SBE decoder (compile-time layouts, zero-copy), FAST decoder (stop-bit, presence maps, delta operators), OUCH 4.2 encoder/decoder, PITCH 2.x parser (7 message types).
+- Exceptions: SBE uses compile-time layout definitions instead of XML schema parsing.
+
+## Worktree 5 — trading-desk-kraken-integration-03-01 (Batch 3)
+
+Path: .worktrees/trading-desk-kraken-integration-03-01
+Phases: 3
+
+### Phase 3: WebSocket + Kraken REST
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 283/283 tests passed`
+- Recovery attempts: none needed
+- Details: WebSocket frame encode/decode + client, Kraken spot auth (HMAC-SHA512), spot REST client (all public+private endpoints), spot rate limiter, futures auth+REST+rate limiter. 47 new tests.
+- Exceptions: None
+
+## Worktree 6 — trading-desk-kraken-integration-03-02 (Batch 3)
+
+Path: .worktrees/trading-desk-kraken-integration-03-02
+Phases: 5
+
+### Phase 5: FIX Protocol + Kraken FIX Connectivity
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 48/48 tests passed`
+- Recovery attempts: none needed
+- Details: FIX tag-value codec (SOH delimiter, checksum), FIX session layer (Logon/Logout/Heartbeat/TestRequest/ResendRequest/SequenceReset), seq_store, Kraken FIX client (SenderCompID auth, nonce signing).
+- Exceptions: None
+
+## Worktree 7 — trading-desk-kraken-integration-03-03 (Batch 3)
+
+Path: .worktrees/trading-desk-kraken-integration-03-03
+Phases: 8
+
+### Phase 8: Position Tracking + P&L + Risk Calculations
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 266/266 tests passed`
+- Recovery attempts: none needed
+- Details: PositionManager (FIFO/LIFO/avg cost basis, realized/unrealized P&L), VaR (historical/parametric/Monte Carlo), Expected Shortfall, Black-Scholes Greeks (delta/gamma/vega/theta/rho/implied vol), stress testing, math utilities (Cholesky, Box-Muller, sort).
+- Exceptions: None
+
+## Worktree 8 — trading-desk-kraken-integration-04-01 (Batch 4)
+
+Path: .worktrees/trading-desk-kraken-integration-04-01
+Phases: 4
+
+### Phase 4: Kraken WebSocket Streaming + Market Data + Order Book
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 65/65 steps succeeded; 437/437 tests passed`
+- Recovery attempts: none needed
+- Details: Kraken spot WS v2 client, futures WS client (challenge auth, 60s ping), SymbolMapper, L2Book (sorted levels, O(1) BBO), L3Book (per-order hash map), BarAggregator (time/volume/tick). 76 new tests.
+- Exceptions: None
+
+## Worktree 9 — trading-desk-kraken-integration-04-02 (Batch 4)
+
+Path: .worktrees/trading-desk-kraken-integration-04-02
+Phases: 11
+
+### Phase 11: Post-Trade + Reconciliation + Tick Store
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 65/65 steps succeeded; 18/18 tests passed`
+- Recovery attempts: none needed
+- Details: ReconEngine (trade/position/cash recon with tolerance matching), EodProcessor (snapshots, daily P&L), trade allocation (pro-rata), TickStore (delta-encoded, date-partitioned), ParquetWriter (PAR1 magic, column chunks).
+- Exceptions: None
+
+## Worktree 10 — trading-desk-kraken-integration-05-01 (Batch 5)
+
+Path: .worktrees/trading-desk-kraken-integration-05-01
+Phases: 7
+
+### Phase 7: Kraken Order Execution End-to-End
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 81/81 steps succeeded; 31 new tests passed`
+- Recovery attempts: none needed
+- Details: SpotExecutor (place/cancel/amend via FIX>WS>REST routing), FuturesExecutor (place/cancel, dead man's switch), SymbolTranslator (bidirectional spot+futures mapping).
+- Exceptions: order_types accessed via oms module to avoid multi-module file conflict in Zig 0.13.
+
+## Worktree 11 — trading-desk-kraken-integration-05-02 (Batch 5)
+
+Path: .worktrees/trading-desk-kraken-integration-05-02
+Phases: 10
+
+### Phase 10: Execution Algorithms + Smart Order Routing
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 85/85 steps succeeded; 5/5 tests passed`
+- Recovery attempts: none needed
+- Details: TWAP (equal slices + jitter), VWAP (volume profile, participation), POV (target %), IS algo (arrival price, adaptive urgency), Iceberg (display qty, refill), Sniper (book depth trigger), SOR (venue scoring by price/fees/latency/fill rate).
+- Exceptions: SOR best_score init fixed to -inf. MarketState inner struct extracted to named VenueBook for cross-module compat.
+
+## Worktree 12 — trading-desk-kraken-integration-05-03 (Batch 5)
+
+Path: .worktrees/trading-desk-kraken-integration-05-03
+Phases: 12
+
+### Phase 12: Trading Strategies + Analytics
+
+- Status: `passed`
+- Checkpoint command: `zig build test --summary all 2>&1`
+- Expected output: `all passed`
+- Actual result: `exit 0 — 218/218 tests passed`
+- Recovery attempts: none needed
+- Details: TCA engine (IS decomposition, VWAP slippage, spread capture, fill rate), BrinsonAttribution (allocation/selection/interaction), VPIN calculator, basis trading strategy (spot vs futures), funding rate arbitrage strategy.
+- Exceptions: None
+
+## Summary
+- [x] All phases complete (12/12)
+- [x] All checkpoints passed (12/12 — zero failures, zero recovery attempts needed)
+- [x] Exceptions documented (minor deviations noted per phase)
+- [x] Batches auto-merged (5 batches, 12 worktrees)
+- [x] Worktrees cleaned up
+- [x] Ready for PR
+
+Final test count: 101/101 build steps succeeded on main after all merges.

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/08-pull-request-01.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/08-pull-request-01.md
@@ -1,0 +1,104 @@
+---
+phase: 8
+iteration: 01
+generated: 2026-04-03
+---
+
+PR Title: Add pure-Zig trading platform SDK with Kraken exchange integration
+
+Closes: #9
+
+## What problem does this solve?
+
+This implements a complete professional trading platform SDK in pure Zig with zero external dependencies, providing every building block needed for institutional-grade trading: from low-level I/O and cryptography through wire protocols, order management, risk calculations, execution algorithms, and analytics. Kraken (spot + futures) serves as the first exchange adapter, demonstrating the full stack end-to-end.
+
+## User-facing changes
+
+This is a greenfield implementation — all changes are new. The SDK provides:
+- **129 new source files** across 5 layers: `sdk/core/`, `sdk/protocol/`, `sdk/domain/`, `exchanges/kraken/`, `trading/`
+- **23,795 lines** of pure Zig with comprehensive test coverage
+- Complete Kraken spot and futures connectivity (REST, WebSocket v2, FIX)
+- Order management, execution algorithms, risk calculations, and analytics ready for use
+
+## Implementation summary
+
+**Key design decisions** (from Phase 3):
+- **Full platform scope**: All components built as native Zig — no external libraries, no C interop, no `.zon` dependencies
+- **Layered module architecture**: `sdk/core` → `sdk/protocol` → `sdk/domain` with strict dependency direction; `exchanges/` and `trading/` as consumers
+- **Custom TLS 1.2/1.3**: Built on `std.crypto` primitives (AES-GCM, ChaCha20-Poly1305, X25519, RSA, ECDSA, X.509) for full control
+- **Arena + pool allocators**: Cache-line aligned (64 bytes), pre-allocated pools for hot-path objects, conforming to `std.mem.Allocator` interface
+- **io_uring + pinned threads**: io_uring event loop for I/O; SPSC ring buffers for zero-contention inter-thread data flow
+- **All wire protocols native**: JSON, FIX, SBE, FAST, ITCH, OUCH, PITCH — covers Kraken and traditional/electronic venues
+- **L2 + L3 order books**: Market-by-Price for Kraken; Market-by-Order for MBO exchanges; shared `BookView` interface
+
+**Edge cases handled** (from Phase 5):
+- FIX session: PossDupFlag handling for ResendRequest/SequenceReset, sequence gap detection
+- Order state machine: fill-before-cancel, fill-before-replace, unsolicited cancel race conditions
+- WebSocket: Cloudflare rate limit awareness (150 reconnects/10 min), automatic ping/pong keepalive
+- Kraken auth: Spot vs futures use different HMAC-SHA512 input construction despite same algorithm
+- Reconciliation: configurable tolerances for trade/position/cash matching with break management
+
+**Test checkpoints passed** (from Phase 7):
+- Phase 1 — `zig build test --summary all`: passed (46/46 tests)
+- Phase 2 — `zig build test --summary all`: passed (48/48 tests)
+- Phase 3 — `zig build test --summary all`: passed (283/283 tests)
+- Phase 4 — `zig build test --summary all`: passed (437/437 tests)
+- Phase 5 — `zig build test --summary all`: passed (48/48 tests)
+- Phase 6 — `zig build test --summary all`: passed (12/12 tests)
+- Phase 7 — `zig build test --summary all`: passed (31 new tests)
+- Phase 8 — `zig build test --summary all`: passed (266/266 tests)
+- Phase 9 — `zig build test --summary all`: passed (101/101 tests)
+- Phase 10 — `zig build test --summary all`: passed (5/5 tests)
+- Phase 11 — `zig build test --summary all`: passed (18/18 tests)
+- Phase 12 — `zig build test --summary all`: passed (218/218 tests)
+
+## Implementation approach
+
+The implementation was executed in 12 phases across 5 batches using parallel worktrees:
+
+**Batch 1** — Project skeleton + core primitives (memory, time, containers, crypto)
+**Batch 2** — I/O + TLS + HTTP + JSON | OMS + order types + risk + event store | Market data protocols (SBE, FAST, ITCH, OUCH, PITCH)
+**Batch 3** — WebSocket + Kraken REST | FIX protocol + Kraken FIX | Position tracking + P&L + risk calcs
+**Batch 4** — Kraken WS streaming + market data + order book | Post-trade + reconciliation + tick store
+**Batch 5** — Kraken order execution E2E | Execution algorithms + SOR | Trading strategies + analytics
+
+Key technical choices:
+- `MpscQueue` uses allocator-based init rather than self-referential `init()` to work within Zig 0.13 constraints
+- `X25519` delegates to `std.crypto.dh.X25519` (only crypto primitive using std directly)
+- SBE uses compile-time layout definitions instead of XML schema parsing for zero-overhead decoding
+- `OrderManager` uses `anyopaque` + function pointers to avoid circular dependency between modules
+- `order_types` accessed via `oms` module to avoid multi-module file conflicts in Zig 0.13
+- SOR `best_score` initialized to `-inf` for correct venue comparison
+- `MarketState` inner struct extracted to named `VenueBook` for cross-module compatibility
+
+## Exceptions and deviations
+
+Minor deviations from the plan, all documented per phase:
+- Phase 1: `MpscQueue` init pattern changed; `X25519` delegates to std; minor test vector corrections
+- Phase 6: `OrderManager` uses `anyopaque` + function pointers for dependency management
+- Phase 7: `order_types` accessed via `oms` module path
+- Phase 9: SBE uses compile-time layouts instead of XML schema parsing
+- Phase 10: SOR best_score init fixed; `VenueBook` struct extracted
+
+No deviations affected the design goals or API surface.
+
+## How to verify
+
+### Automated
+- [ ] `zig build test --summary all` — runs all 101 build steps and full test suite
+- [ ] All 12 phase checkpoints passed with zero failures and zero recovery attempts
+
+### Manual
+- [ ] Verify layered module structure: `sdk/core/` → `sdk/protocol/` → `sdk/domain/` → `exchanges/kraken/` → `trading/`
+- [ ] Verify zero external dependencies: no `.zon` dependency file, no C imports
+- [ ] Spot-check Kraken auth: `exchanges/kraken/spot/auth.zig` implements HMAC-SHA512 with base64-decoded secret
+- [ ] Spot-check FIX session: `sdk/protocol/fix/session.zig` handles Logon/Logout/Heartbeat/ResendRequest
+- [ ] Spot-check order state machine: `sdk/domain/oms.zig` validates FIX-standard state transitions
+
+## Breaking changes / migration notes
+
+None — this is a greenfield implementation with no prior code.
+
+## Changelog entry
+
+Add complete pure-Zig trading platform SDK with Kraken spot and futures exchange integration, covering core primitives, wire protocols (TLS, HTTP, WebSocket, JSON, FIX, SBE, FAST, ITCH, OUCH, PITCH), order management, risk calculations, execution algorithms, smart order routing, position tracking, post-trade reconciliation, and trading analytics

--- a/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/meta.md
+++ b/.claude/specs/_archive/trading-desk-kraken-integration-2026-04-03/meta.md
@@ -1,0 +1,30 @@
+# Spec Metadata: Professional Trading Desk with Kraken Exchange Integration
+
+feature-slug: trading-desk-kraken-integration
+github-owner: ChristianPresley
+github-repo: trading-platform
+tracking-issue: 9
+
+## Phase issues
+- Phase 1: #11 — Project Skeleton + Core Primitives
+- Phase 2: #12 — I/O + TLS + HTTP + JSON
+- Phase 3: #13 — WebSocket + Kraken REST
+- Phase 4: #14 — Kraken WebSocket Streaming + Market Data + Order Book
+- Phase 5: #15 — FIX Protocol + Kraken FIX Connectivity
+- Phase 6: #16 — OMS + Order Types + Pre-Trade Risk + Event Store
+- Phase 7: #17 — Kraken Order Execution End-to-End
+- Phase 8: #18 — Position Tracking + P&L + Risk Calculations
+- Phase 9: #19 — Additional Market Data Protocols (SBE, FAST, ITCH, OUCH, PITCH)
+- Phase 10: #20 — Execution Algorithms + Smart Order Routing
+- Phase 11: #21 — Post-Trade + Reconciliation + Tick Store
+- Phase 12: #22 — Trading Strategies + Analytics
+
+## Phase iterations
+- Phase 1 (questions): 01
+- Phase 2 (research): 01
+- Phase 3 (design): 01
+- Phase 4 (outline): 01
+- Phase 5 (plan): 01
+- Phase 6 (worktree): 01
+- Phase 7 (implement): 01
+- Phase 8 (pull-request): 01


### PR DESCRIPTION
## Summary
- Archives the Phase 1–8 spec pipeline documents from the trading-desk-kraken-integration feature into `.claude/specs/_archive/`

## Test plan
- [x] No code changes — spec documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)