### PR TITLE
chore: update spec agents and add trading-desk-tui specs

### DIFF
--- a/.claude/agents/spec.07.implement.md
+++ b/.claude/agents/spec.07.implement.md
@@ -39,7 +39,13 @@ If either is missing, return an error.
 
 2. **Initialize implementation log** at `.claude/specs/{slug}/07-implementation-{NN}.md` with worktree structure and `in-progress` status for all phases.
 
-3. **Spawn worker agents in parallel** for all worktrees in the current batch. Launch all in a single message. For each worktree:
+3. **Copy spec documents into the first worktree** before spawning any workers:
+   ```bash
+   cp -r .claude/specs/{slug}/ {first-worktree-path}/.claude/specs/{slug}/
+   ```
+   This ensures the spec pipeline artifacts (questions, research, design, outline, plan, worktree doc) are committed alongside the implementation. Only do this for the **first worktree in batch 1** — later batches inherit via merge.
+
+4. **Spawn worker agents in parallel** for all worktrees in the current batch. Launch all in a single message. For each worktree:
 
    ```yaml
    subagent_type: "spec.07.worker"
@@ -50,19 +56,22 @@ If either is missing, return an error.
      Branch: {branch-name}
      Assigned phases: {phase numbers and names}
      Plan file: {plan-path}
+     Include spec docs: {true if first worktree in batch 1, false otherwise}
 
      Implement the assigned phases exactly as described in the plan.
      Report back: phases completed, checkpoint results (pass/fail + output), any exceptions.
    ```
 
-4. **Wait for all agents in the current batch.** Update the implementation log sequentially as each completes. For each passing phase, close its GitHub issue (from `meta.md`) with:
+   For the first worktree in batch 1, set `Include spec docs: true`. This tells the worker to commit the spec documents (already copied in step 3) as its first commit before implementing phases.
+
+5. **Wait for all agents in the current batch.** Update the implementation log sequentially as each completes. For each passing phase, close its GitHub issue (from `meta.md`) with:
    ```
    Phase {N} complete — checkpoint passed.
    Command: `{command}`
    Output: {snippet}
    ```
 
-5. **On checkpoint failure — spawn recovery agent (up to 3 attempts):**
+6. **On checkpoint failure — spawn recovery agent (up to 3 attempts):**
 
    For each attempt, spawn the diagnostic agent:
    ```yaml
@@ -93,21 +102,21 @@ If either is missing, return an error.
    - Two simultaneous agent failures → escalate immediately (no parallel recovery)
    - >2 failed phases in same worktree → circuit breaker, stop and escalate
 
-6. **Auto-merge each batch** after all checkpoints pass:
+7. **Auto-merge each batch** after all checkpoints pass:
    ```bash
    git merge {branch} --no-ff -m "feat({slug}): merge batch {N} — {branch}"
    ```
    Merge conflicts → do NOT auto-resolve. List conflicting files, escalate to engineer.
 
-7. **Worktree cleanup** after each merged batch:
+8. **Worktree cleanup** after each merged batch:
    ```bash
    git worktree remove .worktrees/{slug}-{NN}
    ```
    Verify commits are reachable from main first. Never remove with uncommitted/unmerged changes. Do NOT delete feature branches (retained for Phase 8/9).
 
-8. **Spawn next batch** automatically after merge + cleanup. No confirmation needed.
+9. **Spawn next batch** automatically after merge + cleanup. No confirmation needed.
 
-9. **Final update** — update implementation log summary. Check off Phase 7 in tracking issue. Update meta.md.
+10. **Final update** — update implementation log summary. Check off Phase 7 in tracking issue. Update meta.md.
 
 ## Escalation Path
 

--- a/.claude/agents/spec.07.worker.md
+++ b/.claude/agents/spec.07.worker.md
@@ -30,7 +30,15 @@ Your prompt contains:
 
 1. **Read the plan file fully** before making any changes.
 
-2. **For each assigned phase** (in order):
+2. **If `Include spec docs: true`** — commit the spec documents before implementing phases:
+   ```bash
+   cd {worktree-path}
+   git add .claude/specs/{slug}/
+   git commit -m "docs({slug}): add spec pipeline artifacts"
+   ```
+   This ensures all spec documents (questions, research, design, outline, plan, worktree doc) are tracked in version control as the first commit on this branch.
+
+3. **For each assigned phase** (in order):
 
    a. **Implement** all changes listed under that phase in the plan:
       - New files: create with the specified structure
@@ -50,7 +58,7 @@ Your prompt contains:
 
    d. **If reality diverges from plan** (file missing, interface changed, unexpected state): STOP. Report as an exception. Do NOT improvise or work around it.
 
-3. **After all phases complete**: commit all changes on the assigned branch:
+4. **After all phases complete**: commit all changes on the assigned branch:
    ```bash
    cd {worktree-path}
    git add -A

--- a/.claude/specs/trading-desk-tui/01-questions-01.md
+++ b/.claude/specs/trading-desk-tui/01-questions-01.md
@@ -1,0 +1,36 @@
+---
+phase: 1
+iteration: 01
+generated: 2026-04-03
+---
+
+# Research Questions: Trading Desk TUI Application
+
+Source issue: Feature request — build a runnable trading desk application with terminal UI, executable targets, and VS Code dev tasks
+Feature slug: trading-desk-tui
+
+## Questions
+
+1. What are the public APIs (struct types, init/deinit signatures, and key methods) exposed by `sdk/domain/orderbook.zig`, `sdk/domain/orderbook_l3.zig`, `sdk/domain/oms.zig`, `sdk/domain/positions.zig`, `sdk/domain/market_data.zig`, and `sdk/domain/risk/pre_trade.zig` that a consuming application would need to instantiate and drive?
+
+2. How does the existing `sdk/core/io/event_loop.zig` work — what is its public API for registering sockets, timers, and running the loop, and what are the constraints of its io_uring-based design (e.g., Linux-only, blocking vs non-blocking)?
+
+3. How does `sdk/core/memory.zig` provide allocation — what allocator types and patterns does it expose, and how do existing modules (OMS, orderbook, positions) obtain their allocators?
+
+4. How do the Kraken exchange executors (`exchanges/kraken/spot/executor.zig` and `exchanges/kraken/futures/executor.zig`) interface with the OMS — what are their public init/submit/cancel signatures, and what callback or event mechanisms do they use to report fills and status changes?
+
+5. How does the existing `build.zig` structure its module graph — what is the pattern for creating modules, wiring inter-module imports (e.g., `addImport`), and registering build steps, and what are the existing named steps (`test`, `test-core`, `test-protocol`, `test-ws`, `test-kraken`)?
+
+6. What terminal I/O primitives does Zig's `std` library provide — specifically `std.posix.tcgetattr`/`tcsetattr` for raw mode, `std.io.getStdIn()`/`getStdOut()` for file descriptors, and `std.os.linux.IoUring` for non-blocking stdin reads — that would be needed to build a TUI without external dependencies?
+
+7. How do the trading strategies (`trading/strategies/basis.zig`, `trading/strategies/funding_arb.zig`) consume orderbook and market data — what types do they import, and what is their interface for receiving updates and emitting signals?
+
+8. What are the public types and methods in `sdk/domain/risk/var.zig`, `sdk/domain/risk/greeks.zig`, and `sdk/domain/risk/stress.zig` that expose risk metrics a dashboard would display?
+
+9. How do the analytics modules (`trading/analytics/tca.zig`, `trading/analytics/vpin.zig`, `trading/analytics/attribution.zig`) expose their computed metrics — what are their public result types and computation entry points?
+
+10. What does the existing `.vscode/trading-platform.code-workspace` contain, and what Zig-specific VS Code task and launch configuration patterns exist for `zig build` executables (task problemMatchers, debug adapter type, etc.)?
+
+11. How does `sdk/core/time.zig` provide timestamps — what clock sources and types does it expose, and how do other modules (OMS, positions, event_loop) consume time values?
+
+12. What is the structure and API of `sdk/core/containers/ring_buffer.zig` and `sdk/core/containers/mpsc_queue.zig` — and how could they serve as the communication mechanism between an event loop thread and a TUI rendering thread?

--- a/.claude/specs/trading-desk-tui/02-research-01.md
+++ b/.claude/specs/trading-desk-tui/02-research-01.md
@@ -1,0 +1,321 @@
+---
+phase: 2
+iteration: 01
+generated: 2026-04-03
+---
+
+# Research: Trading Desk TUI Application
+
+Questions source: .claude/specs/trading-desk-tui/01-questions-01.md
+
+## 1. Public APIs of domain modules (orderbook, OMS, positions, market_data, risk/pre_trade)
+
+### sdk/domain/orderbook.zig
+- `Side` enum: `bid`, `ask` (`orderbook.zig:8`)
+- `Level` struct: `price: i64, quantity: i64` (`orderbook.zig:10-13`)
+- `L2Book` struct with fields: `allocator`, `bids_buf`, `asks_buf`, `bids_len`, `asks_len`, `depth` (`orderbook.zig:15-21`)
+- `L2Book.init(allocator: std.mem.Allocator, depth: usize) !L2Book` — pre-allocates sorted arrays (`orderbook.zig:24`)
+- `L2Book.applySnapshot(self, bid_levels, ask_levels) void` — replaces entire book (`orderbook.zig:39`)
+- `L2Book.applyUpdate(self, side: Side, price: i64, qty: i64) void` — incremental update, qty=0 removes (`orderbook.zig:65`)
+- `L2Book.bestBid(self) ?Level`, `L2Book.bestAsk(self) ?Level` — O(1) BBO access (`orderbook.zig:124,130`)
+- `L2Book.spread(self) ?i64`, `L2Book.midPrice(self) ?i64` — derived metrics (`orderbook.zig:136,143`)
+- `L2Book.bids(self) []const Level`, `L2Book.asks(self) []const Level` — full depth slices (`orderbook.zig:150,155`)
+- `L2Book.deinit(self) void` (`orderbook.zig:159`)
+- All prices use fixed-point i64 (satoshis/cents) (`orderbook.zig:4`)
+
+### sdk/domain/orderbook_l3.zig
+- `L3Book` struct with `allocator` and `orders: std.AutoHashMap(u64, OrderInfo)` (`orderbook_l3.zig:21-23`)
+- `OrderInfo` struct: `order_id: u64, side: Side, price: i64, quantity: i64` (`orderbook_l3.zig:14-19`)
+- `L3Book.init(allocator) !L3Book` (`orderbook_l3.zig:25`)
+- `L3Book.addOrder(self, order_id, side, price, qty) !void` (`orderbook_l3.zig:33`)
+- `L3Book.modifyOrder(self, order_id, new_qty) !void` (`orderbook_l3.zig:44`)
+- `L3Book.deleteOrder(self, order_id) !void` (`orderbook_l3.zig:50`)
+- `L3Book.getOrder(self, order_id) ?OrderInfo` — O(1) hash map lookup (`orderbook_l3.zig:55`)
+- `L3Book.bestBid(self) ?Level`, `L3Book.bestAsk(self) ?Level` — O(n) scans all orders (`orderbook_l3.zig:60,81`)
+- `L3Book.deinit(self) void` (`orderbook_l3.zig:101`)
+
+### sdk/domain/oms.zig
+- Re-exports from `order_types.zig`: `OrderId` (u64), `OrderType`, `TimeInForce`, `Side` (`oms.zig:4-7`)
+- `OrdStatus` enum: 14 states including `pending_new`, `new`, `partially_filled`, `filled`, `cancelled`, `rejected`, etc. (`oms.zig:10-25`)
+- `ExecType` enum: 11 execution event types (`oms.zig:28-40`)
+- `Order` struct: `id`, `instrument`, `side`, `order_type`, `quantity`, `price`, `tif`, `status`, `created_at: u128`, `parent_id`, `filled_qty` (`oms.zig:56-68`)
+- `OrderStateMachine` with `transition(current, event) !OrdStatus` and `isTerminal(status) bool` (`oms.zig:71-164`)
+- `OrderManager` struct: `allocator`, `risk: *anyopaque`, `store: *anyopaque`, `orders: std.AutoHashMap(OrderId, Order)`, `next_id`, `sm` (`oms.zig:171-177`)
+- `OrderManager.init(allocator, risk, store, risk_validate_fn, store_append_fn) !OrderManager` — uses function pointer injection for risk and event store (`oms.zig:183-200`)
+- `OrderManager.submitOrder(self, order) !OrderId` — validates via risk, assigns ID, emits event (`oms.zig:204`)
+- `OrderManager.cancelOrder(self, id) !void` — transitions to pending_cancel (`oms.zig:226`)
+- `OrderManager.replaceOrder(self, id, new_params) !OrderId` — creates replacement order (`oms.zig:238`)
+- `OrderManager.onExecution(self, id, exec, fill) !void` — processes execution reports from exchange (`oms.zig:270`)
+- `OrderManager.getOrder(self, id) ?*const Order` (`oms.zig:285`)
+- `OrderManager.deinit(self) void` (`oms.zig:289`)
+
+### sdk/domain/positions.zig
+- `PositionKey` struct: `account`, `instrument`, `settlement_date: u32`, `currency` (all []const u8 except date) (`positions.zig:11-16`)
+- `Position` struct: `key`, `quantity: i64` (net), `avg_cost: i64`, `realized_pnl: i64`, `lots: std.ArrayList(Lot)` (`positions.zig:31-41`)
+- `Lot` struct: `quantity: i64`, `price: i64`, `timestamp: u128` (`positions.zig:24-28`)
+- `Fill` struct: `instrument`, `side`, `quantity`, `price`, `timestamp`, `account`, `currency`, `settlement_date` (`positions.zig:44-53`)
+- `PositionManager.init(allocator, config: PositionConfig) !PositionManager` (`positions.zig:64`)
+- `PositionManager.onFill(self, fill: Fill) !void` — updates position with FIFO/LIFO/avg cost basis (`positions.zig:86`)
+- `PositionManager.getPosition(self, key) ?*const Position` (`positions.zig:229`)
+- `PositionManager.realizedPnl(self, key) ?i64` (`positions.zig:235`)
+- `PositionManager.unrealizedPnl(self, key, mark_price) ?i64` (`positions.zig:243`)
+- `PositionManager.allPositions(self) []const Position` — returns all positions as a slice (`positions.zig:257`)
+- `PositionManager.deinit(self) void` (`positions.zig:73`)
+- `PositionConfig`: `cost_basis_method: CostBasisMethod`, `base_currency: []const u8` (`positions.zig:18-21`)
+
+### sdk/domain/market_data.zig
+- This file is actually the **symbol mapper** (Kraken symbol normalization), not a general market data bus (`market_data.zig:1-3`)
+- `SymbolMapper` struct with `init(allocator) !SymbolMapper` (`market_data.zig:59-64`)
+- `spotToInternal(kraken_pair) ?[]const u8`, `futurestoInternal(kraken_symbol) ?[]const u8` (`market_data.zig:68,79`)
+- `internalToSpot(internal) ?[]const u8`, `internalToFutures(internal) ?[]const u8` (`market_data.zig:90,101`)
+- Uses compile-time static tables `SPOT_MAP` (20 entries) and `FUTURES_MAP` (12 entries) — no heap allocation (`market_data.zig:18-55`)
+- There is no general-purpose market data feed/bus/dispatcher module in the codebase
+
+### sdk/domain/risk/pre_trade.zig
+- `RiskConfig`: `max_order_size`, `max_notional`, `max_position`, `max_order_rate`, `price_band_pct`, `dedup_window_ms` (`pre_trade.zig:22-28`)
+- `PreTradeRisk.init(allocator, config: RiskConfig) !PreTradeRisk` (`pre_trade.zig:59`)
+- `PreTradeRisk.validate(self, order: *const Order) ValidationResult` — returns `.passed` or `.rejected: RejectReason` (`pre_trade.zig:89`)
+- `PreTradeRisk.setReferencePrice(self, instrument, price) !void` (`pre_trade.zig:78`)
+- `PreTradeRisk.updatePosition(self, instrument, delta) !void` (`pre_trade.zig:83`)
+- `ValidationResult` is a tagged union: `passed` or `rejected: RejectReason` (`pre_trade.zig:17-19`)
+- `RejectReason` enum: `invalid_order`, `size_exceeded`, `price_unreasonable`, `position_limit`, `rate_exceeded`, `duplicate_detected` (`pre_trade.zig:7-14`)
+- `PreTradeRisk.deinit(self) void` (`pre_trade.zig:70`)
+
+## 2. Event loop (sdk/core/io/event_loop.zig) — API and design constraints
+
+- `EventLoop` struct: `allocator`, `ring: std.os.linux.IoUring`, `sockets: std.ArrayList(SocketEntry)`, `timers: std.ArrayList(TimerEntry)`, `running: bool`, `read_buf: [65536]u8` (`event_loop.zig:21-27`)
+- `EventLoop.init(allocator) !EventLoop` — creates io_uring with 256 SQ entries (`event_loop.zig:29-30`)
+- `Handler` struct: function pointers `onRead(*const fn(fd, data) void)` and `onError(*const fn(fd, err) void)` (`event_loop.zig:6-9`)
+- `EventLoop.addSocket(self, fd, handler) !void` — registers a socket with a handler (`event_loop.zig:41`)
+- `EventLoop.addTimer(self, timeout_ms, callback) !void` — registers a timer callback (`event_loop.zig:45`)
+- `EventLoop.removeSocket(self, fd) void` (`event_loop.zig:49`)
+- `EventLoop.run(self) !void` — blocking loop: submits io_uring read requests for all registered sockets, waits for CQEs (`event_loop.zig:60-96`)
+- `EventLoop.stop(self) void` — sets `running = false` (`event_loop.zig:98`)
+- `EventLoop.deinit(self) void` (`event_loop.zig:102`)
+- **Linux-only**: depends on `std.os.linux.IoUring` (`event_loop.zig:2,23,30`)
+- **Single read buffer**: shared `read_buf: [65536]u8` across all sockets — reads are serialized (`event_loop.zig:27`)
+- **Blocking**: `run()` blocks the calling thread in a while loop until `stop()` is called (`event_loop.zig:60-96`)
+- Uses `copy_cqe()` which waits for a single completion — one event at a time processing (`event_loop.zig:90`)
+
+## 3. Memory allocation (sdk/core/memory.zig)
+
+- `PoolAllocator` — fixed-slot slab allocator with 64-byte aligned slots (`memory.zig:6-90`)
+  - `init(backing: std.mem.Allocator, slot_size: usize, slot_count: usize) !PoolAllocator` (`memory.zig:18`)
+  - `allocator(self) std.mem.Allocator` — returns `std.mem.Allocator` interface via vtable (`memory.zig:49-53`)
+  - Uses free-list for O(1) alloc/free (`memory.zig:14-16,56-64,75-83`)
+  - `deinit(self) void` — frees backing slab (`memory.zig:45`)
+- `ArenaAllocator` — bump allocator wrapping `std.heap.ArenaAllocator` (`memory.zig:93-111`)
+  - `init(backing: std.mem.Allocator) ArenaAllocator` (`memory.zig:96`)
+  - `allocator(self) std.mem.Allocator` (`memory.zig:104`)
+  - `reset(self) void` — resets with `.retain_capacity` (`memory.zig:108`)
+  - `deinit(self) void` (`memory.zig:100`)
+- `cache_line_size: usize = 64` — public constant (`memory.zig:3`)
+- **Pattern in existing modules**: All domain modules (OMS, orderbook, positions, PreTradeRisk) accept `std.mem.Allocator` as first parameter to `init()`. No module creates its own allocator — they receive one from the caller.
+  - `L2Book.init(allocator, depth)` (`orderbook.zig:24`)
+  - `L3Book.init(allocator)` (`orderbook_l3.zig:25`)
+  - `OrderManager.init(allocator, ...)` (`oms.zig:183`)
+  - `PositionManager.init(allocator, config)` (`positions.zig:64`)
+  - `PreTradeRisk.init(allocator, config)` (`pre_trade.zig:59`)
+
+## 4. Kraken exchange executors and OMS integration
+
+### exchanges/kraken/spot/executor.zig
+- `SpotExecutor` struct: `allocator`, `rest: ?*SpotRestClient`, `ws: ?*SpotWsClient`, `fix: ?*FixSession`, `oms: *OrderManager`, `preferred_channel: RouteChannel`, `mock_response`, `next_txid_counter` (`executor.zig:67-77`)
+- `SpotExecutor.init(allocator, rest, ws, fix, oms) !SpotExecutor` — determines preferred channel as FIX > WS > REST based on which are non-null (`executor.zig:78-97`)
+- `SpotExecutor.placeOrder(self, order: *const Order) !ExchangeOrderId` — translates to Kraken format, routes via preferred channel, calls `oms.onExecution(id, .new, null)` on success or `oms.onExecution(id, .rejected, null)` on failure (`executor.zig:115-169`)
+- `SpotExecutor.cancelOrder(self, oms_id, exchange_id) !void` — calls `oms.onExecution(oms_id, .cancelled, null)` (`executor.zig:172-187`)
+- `SpotExecutor.amendOrder(self, oms_id, exchange_id, params) !ExchangeOrderId` — calls `oms.onExecution(oms_id, .replaced, null)` (`executor.zig:191-214`)
+- `SpotExecutor.processExecutionReport(self, oms_id, exec, fill) !void` — thin wrapper around `oms.onExecution()` (`executor.zig:218-225`)
+- `SpotExecutor.injectResponse(self, resp) void` — test mock injection (`executor.zig:100`)
+- `ExchangeOrderId` struct: fixed `[32]u8` array with `len: u8`, methods `fromSlice()` and `asSlice()` (`executor.zig:25-40`)
+- `RouteChannel` enum: `fix`, `ws`, `rest` (`executor.zig:49-53`)
+- Opaque client types: `SpotRestClient`, `SpotWsClient`, `FixSession` — all are `opaque {}` (`executor.zig:18-22`)
+- When all clients are null, executor still works — generates synthetic txids (`executor.zig:166-168`)
+
+### exchanges/kraken/futures/executor.zig
+- `FuturesExecutor` struct: `allocator`, `rest: ?*FuturesRestClient`, `ws: ?*FuturesWsClient`, `oms: *OrderManager`, `dms: DeadManSwitch`, `mock_response` (`futures/executor.zig:69-78`)
+- `FuturesExecutor.init(allocator, rest, ws, oms) !FuturesExecutor` — no FIX channel for futures (`futures/executor.zig:80-96`)
+- `FuturesExecutor.placeOrder(self, order) !ExchangeOrderId` — same OMS integration pattern as spot (`futures/executor.zig:112-142`)
+- `FuturesExecutor.cancelOrder(self, oms_id, exchange_id) !void` (`futures/executor.zig:145-158`)
+- `FuturesExecutor.processExecutionReport(self, oms_id, exec, fill) !void` (`futures/executor.zig:185-192`)
+- `DeadManSwitch` struct: `enabled`, `timeout_s`, `last_refresh_ns` with `needsRefresh(now_ns) bool` (`futures/executor.zig:37-57`)
+- `FuturesExecutor.setDeadManSwitch(self, timeout_s) !void` (`futures/executor.zig:163`)
+- `FuturesExecutor.refreshDeadManSwitch(self) !void` (`futures/executor.zig:175`)
+- ExchangeOrderId uses `[48]u8` (larger than spot's `[32]u8`) (`futures/executor.zig:19-34`)
+- Both executors can operate with null client references (mock/demo mode) and generate synthetic IDs
+
+## 5. Build system structure (build.zig)
+
+- File is 972 lines (`build.zig:1-972`)
+- Uses `b.standardTargetOptions(.{})` and `b.standardOptimizeOption(.{})` at the top (`build.zig:4-5`)
+- **No executable targets** — only test steps and modules exist
+- **Named build steps**:
+  - `test` — "Run all tests" (`build.zig:8`)
+  - `test-core` — "Run sdk/core tests" (`build.zig:9`)
+  - `test-protocol` — "Run sdk/protocol tests" (`build.zig:401`)
+  - `test-ws` — "Run WebSocket tests" (`build.zig:609`)
+  - `test-kraken` — "Run Kraken exchange tests" (`build.zig:610`)
+- **Module creation pattern**: `b.createModule(.{ .root_source_file = b.path("path/to/file.zig") })` (`build.zig:80-100`)
+- **Inter-module imports**: `module.addImport("name", other_module)` (`build.zig:108,136,141,etc.`)
+- **Anonymous imports for tests**: `test_exe.root_module.addAnonymousImport("name", .{ .root_source_file = ... })` (`build.zig:46-48`)
+- **Test pattern**: `b.addTest(.{...})` -> `b.addRunArtifact(test_exe)` -> `test_step.dependOn(&run.step)` (`build.zig:39-44,346-392`)
+- Modules are created once and shared across multiple test targets (e.g., `oms_mod` used by both oms_test and executor_test) (`build.zig:133-136,169,922,947`)
+- Some modules have duplicate definitions for different build phases (e.g., `orderbook_mod_p12` at line 740 and `orderbook_mod` at line 827)
+
+## 6. Terminal I/O primitives available in Zig's std library
+
+- **Note**: This question asks about Zig stdlib capabilities, not files in this repo. Findings are based on Zig 0.13 standard library knowledge.
+- `std.io.getStdIn() std.fs.File` — returns the stdin file descriptor
+- `std.io.getStdOut() std.fs.File` — returns the stdout file descriptor
+- `std.posix.tcgetattr(fd) !std.posix.termios` — reads terminal attributes
+- `std.posix.tcsetattr(fd, optional_actions, termios) !void` — sets terminal attributes (for raw mode: disable ICANON, ECHO, ISIG, etc.)
+- `std.fs.File.reader()` and `std.fs.File.writer()` — buffered I/O
+- `std.os.linux.IoUring` — can register stdin fd for non-blocking reads via `IORING_OP_READ`
+- `std.posix.poll()` — alternative to io_uring for multiplexing stdin + other fds
+- `std.Thread.spawn()` — for running TUI rendering on a separate thread
+- `std.fmt.bufPrint()` — for formatting ANSI escape sequences into buffers
+- The codebase already uses `std.os.linux.IoUring` in `sdk/core/io/event_loop.zig:30`
+- The codebase already uses `std.posix.clock_gettime` for time in `sdk/core/time.zig:9`
+- The codebase already uses `std.Thread` via `sdk/core/io/thread.zig:37` (`spawnPinned`)
+- No existing terminal/TUI code exists in the codebase
+
+## 7. Trading strategies: orderbook and market data consumption
+
+### trading/strategies/basis.zig
+- Imports `orderbook` module and uses `L2Book` type (`basis.zig:5-6`)
+- `BasisStrategy.init(allocator, config: BasisConfig) !BasisStrategy` (`basis.zig:40`)
+- `BasisStrategy.onMarketData(self, spot: *const L2Book, futures: *const L2Book) ?Signal` — primary entry point (`basis.zig:71`)
+- Reads `L2Book.midPrice()` from both spot and futures books to compute annualized basis (`basis.zig:57-58`)
+- `BasisConfig` fields: `entry_threshold_bps`, `exit_threshold_bps`, `max_position`, `instrument_spot`, `instrument_futures`, `days_to_expiry` (`basis.zig:21-28`)
+- `Signal` struct: `direction: Direction`, `spot_qty`, `futures_qty`, `expected_basis_bps` (`basis.zig:14-19`)
+- `Direction` enum: `enter_long_basis`, `enter_short_basis`, `exit` (`basis.zig:8-12`)
+- `PositionState` enum: `flat`, `long_basis`, `short_basis` — tracked internally (`basis.zig:30`)
+
+### trading/strategies/funding_arb.zig
+- Also imports `orderbook` module and uses `L2Book` (`funding_arb.zig:4-5`)
+- `FundingArbStrategy.init(allocator, config: FundingArbConfig) !FundingArbStrategy` (`funding_arb.zig:30`)
+- Two entry points:
+  - `onFundingRate(self, rate: f64, next_funding_time: u128) ?Signal` — triggered by funding rate updates (`funding_arb.zig:45`)
+  - `onMarketData(self, spot: *const L2Book, perp: *const L2Book) ?Signal` — monitors basis convergence (`funding_arb.zig:106`)
+- Uses `L2Book.midPrice()` to compute perp-spot basis (`funding_arb.zig:107-108`)
+- `FundingArbConfig`: `min_rate_bps`, `max_position`, `instrument_spot`, `instrument_perp` (`funding_arb.zig:17-22`)
+- `FundingDirection` enum: `long_spot_short_perp`, `short_spot_long_perp`, `flat` (`funding_arb.zig:8`)
+- Neither strategy directly imports or depends on exchange clients — they receive L2Book references and return Signal structs
+
+## 8. Risk metrics modules (var, greeks, stress)
+
+### sdk/domain/risk/var.zig
+- `historicalVar(returns: []const f64, confidence: f64) !f64` — sorts return distribution, picks percentile loss (`var.zig:7-30`)
+- `parametricVar(sigma, z_alpha, horizon_days, position_value) f64` — variance-covariance VaR (`var.zig:34`)
+- `monteCarloVar(allocator, covariance, weights, simulations, confidence) !f64` — Cholesky-correlated normal returns (`var.zig:43-108`)
+- `expectedShortfall(returns: []const f64, confidence: f64) !f64` — CVaR, average of tail losses (`var.zig:112-142`)
+- All functions are free-standing (not methods on a struct) — stateless computations (`var.zig:7,34,43,112`)
+- Uses `math.sortAscending`, `math.choleskyDecomposition`, `math.normalRandom` from `risk/math.zig` (`var.zig:2`)
+
+### sdk/domain/risk/greeks.zig
+- `BlackScholes` struct (namespace, no instance state) with static methods (`greeks.zig:30`)
+- `BlackScholes.price(spot, strike, r, sigma, t, is_call) f64` — option price (`greeks.zig:43`)
+- `BlackScholes.delta(spot, strike, r, sigma, t, is_call) f64` (`greeks.zig:77`)
+- `BlackScholes.gamma(spot, strike, r, sigma, t) f64` (`greeks.zig:103`)
+- `BlackScholes.vega(spot, strike, r, sigma, t) f64` (`greeks.zig:111`)
+- `BlackScholes.theta(spot, strike, r, sigma, t, is_call) f64` (`greeks.zig:119`)
+- `BlackScholes.rho(spot, strike, r, sigma, t, is_call) f64` (`greeks.zig:133`)
+- `BlackScholes.impliedVolatility(market_price, spot, strike, r, t, is_call) !f64` — Newton-Raphson (`greeks.zig:147`)
+- Helper functions: `normalPdf(x) f64`, `normalCdf(x) f64` — standard normal distribution (`greeks.zig:4,10`)
+
+### sdk/domain/risk/stress.zig
+- `Position` struct: `instrument: []const u8`, `quantity: i64` (`stress.zig:3-6`)
+- `Shock` struct: `instrument: []const u8`, `price_change_pct: f64` (`stress.zig:8-11`)
+- `StressResult` struct: `scenario: []const u8`, `pnl_impact: f64` (`stress.zig:13-16`)
+- `StressTest.init(allocator) !StressTest` (`stress.zig:27`)
+- `StressTest.addScenario(self, name, shocks: []const Shock) !void` — adds named scenario (`stress.zig:42`)
+- `StressTest.run(self, positions: []const Position, mark_prices: []const i64) ![]StressResult` — runs all scenarios, returns results (`stress.zig:53`)
+- `StressTest.deinit(self) void` (`stress.zig:34`)
+
+## 9. Analytics modules: computed metrics and entry points
+
+### trading/analytics/tca.zig
+- `Execution` struct: `price: i64`, `quantity: i64`, `timestamp: u128`, `side: Side`, `venue: []const u8` (`tca.zig:8-14`)
+- `Benchmark` struct: `arrival_price`, `market_vwap`, `close_price`, `attempted_qty` (all i64) (`tca.zig:16-21`)
+- `TcaReport` struct: `is_cost_bps`, `timing_cost_bps`, `market_impact_bps`, `opportunity_cost_bps`, `vwap_slippage_bps`, `spread_capture`, `fill_rate` (all f64) (`tca.zig:23-31`)
+- `TcaEngine.init(allocator) !TcaEngine` (`tca.zig:36`)
+- `TcaEngine.analyze(self, executions: []const Execution, benchmark: Benchmark) !TcaReport` — main entry point (`tca.zig:47`)
+
+### trading/analytics/vpin.zig
+- `VpinCalculator.init(allocator, bucket_size: i64, num_buckets: u32) !VpinCalculator` (`vpin.zig:27`)
+- `VpinCalculator.onTrade(self, price: i64, volume: i64, side: Side) ?f64` — processes trade, returns VPIN estimate when bucket completes (`vpin.zig:52`)
+- Uses tick rule for trade classification internally (`vpin.zig:55-62`)
+- Maintains ring buffer of bucket imbalances (`vpin.zig:14-15`)
+- `VpinCalculator.deinit(self) void` (`vpin.zig:44`)
+
+### trading/analytics/attribution.zig
+- `Holding` struct: `sector: []const u8`, `weight: f64`, `return_pct: f64` (`attribution.zig:6-10`)
+- `AttributionResult` struct: `allocation: f64`, `selection: f64`, `interaction: f64`, `total: f64` (`attribution.zig:12-17`)
+- `BrinsonAttribution.compute(portfolio: []const Holding, benchmark: []const Holding) AttributionResult` — static, no instance state (`attribution.zig:28`)
+- Brinson-Fachler model: decomposes active return into allocation, selection, and interaction effects (`attribution.zig:25-27`)
+
+## 10. VS Code configuration and Zig task/launch patterns
+
+- `.vscode/trading-platform.code-workspace` contains only a folder reference pointing to `..` (the repo root) (`trading-platform.code-workspace:1-7`)
+- No `tasks.json` exists in `.vscode/`
+- No `launch.json` exists in `.vscode/`
+- The workspace file has no tasks, settings, or launch configurations embedded
+- **Zig build system context**: `build.zig` uses `b.standardTargetOptions(.{})` and `b.standardOptimizeOption(.{})` (`build.zig:4-5`), meaning executables support `-Doptimize=ReleaseFast` and `-Dtarget=...` CLI flags
+- The Zig build steps are invoked via `zig build <step-name>`, e.g., `zig build test`, `zig build test-core`
+
+## 11. Time module (sdk/core/time.zig)
+
+- `Timestamp` struct with single field `nanos: u128` (`time.zig:3-4`)
+- `Timestamp.now() Timestamp` — reads `CLOCK_MONOTONIC` (comment says MONOTONIC_RAW but code uses `CLOCK.MONOTONIC`) (`time.zig:7-11`)
+- `Timestamp.wallClock() Timestamp` — reads `CLOCK_REALTIME` (`time.zig:14-18`)
+- `Timestamp.fromUnixNanos(n: u128) Timestamp` — construct from raw nanos (`time.zig:26`)
+- `Timestamp.toRfc3339(self, buf) []const u8` — formats as ISO 8601 with nanoseconds (`time.zig:31`)
+- `Timestamp.toIso8601(self, buf) []const u8` — formats as `YYYYMMDD-HH:MM:SS.nnn` (`time.zig:42`)
+- `Timestamp.toFixUtc(self, buf) []const u8` — alias for toIso8601 (`time.zig:54`)
+- `Timestamp.fromRfc3339(s: []const u8) !Timestamp` — parses RFC 3339 strings (`time.zig:59`)
+- Uses Howard Hinnant's civil_from_days algorithm for date decomposition (`time.zig:117-131`)
+- **Usage by other modules**:
+  - OMS `Order.created_at` is `u128` (raw nanoseconds, not Timestamp struct) (`oms.zig:66`)
+  - Positions `Lot.timestamp` and `Fill.timestamp` are `u128` (`positions.zig:27,49`)
+  - EventLoop does not reference time.zig — it uses `std.os.linux.kernel_timespec` directly (`event_loop.zig:76-79`)
+  - PreTradeRisk uses `std.posix.clock_gettime(CLOCK.MONOTONIC)` directly, not time.zig (`pre_trade.zig:170-172`)
+  - FuturesExecutor uses `std.time.nanoTimestamp()` directly (`futures/executor.zig:166,178`)
+- Time values across the codebase are raw `u128` nanoseconds or `u64` nanoseconds — the `Timestamp` struct is not universally used
+
+## 12. Container data structures (ring_buffer, mpsc_queue)
+
+### sdk/core/containers/ring_buffer.zig
+- `SpscRingBuffer(comptime T: type)` — generic single-producer single-consumer lock-free ring buffer (`ring_buffer.zig:4`)
+- `init(allocator, capacity: usize) !Self` — rounds capacity to next power of 2 (`ring_buffer.zig:14`)
+- `push(self, item: T) bool` — non-blocking, returns false if full (`ring_buffer.zig:31`)
+- `pop(self) ?T` — non-blocking, returns null if empty (`ring_buffer.zig:41`)
+- Uses `std.atomic.Value(usize)` for `write_idx` and `read_idx` with acquire/release ordering (`ring_buffer.zig:11-12,32-33,42-43`)
+- `deinit(self) void` (`ring_buffer.zig:26`)
+- Masking via `capacity - 1` for power-of-2 indexing (`ring_buffer.zig:35,46`)
+
+### sdk/core/containers/mpsc_queue.zig
+- `MpscQueue(comptime T: type)` — generic multi-producer single-consumer intrusive queue (`mpsc_queue.zig:5`)
+- `Node` struct: `next: std.atomic.Value(?*Node)`, `data: T` with `init(data) Node` (`mpsc_queue.zig:9-18`)
+- `initAlloc(allocator) !Self` — allocates a sentinel node (`mpsc_queue.zig:30`)
+- `push(self, node: *Node) void` — lock-free via atomic swap on tail; safe for multiple producers (`mpsc_queue.zig:50-53`)
+- `pop(self) ?*Node` — single-consumer, returns null if empty (`mpsc_queue.zig:58-66`)
+- Uses `seq_cst` ordering for push, `acquire` for pop (`mpsc_queue.zig:51-52,60`)
+- `deinit(self) void` — frees sentinel (`mpsc_queue.zig:44`)
+- Intrusive design: callers must allocate `Node` instances externally
+- **Thread safety profile**: SpscRingBuffer supports exactly one producer and one consumer thread; MpscQueue supports multiple producer threads and one consumer thread
+
+## Cross-cutting observations
+
+- **Allocator injection pattern**: Every domain module accepts `std.mem.Allocator` as first parameter to `init()`. None create allocators internally. This allows a top-level application to provide either `PoolAllocator.allocator()`, `ArenaAllocator.allocator()`, or any other `std.mem.Allocator` implementation (`memory.zig:49,104`, `orderbook.zig:24`, `oms.zig:183`, `positions.zig:64`)
+- **Fixed-point pricing**: All prices and quantities are `i64` throughout the codebase — orderbook, OMS, positions, executors all use integer arithmetic. Kraken executors format as decimal with 8 decimal places for exchange communication (`orderbook.zig:4`, `executor.zig:131-135`)
+- **Init/deinit convention**: Every struct follows `init() !T` / `deinit(*T) void` pattern consistently (`orderbook.zig:24,159`, `oms.zig:183,289`, etc.)
+- **No application entry point**: There are no executable targets in `build.zig` (line 972 total, no `b.addExecutable` calls). The codebase is entirely libraries and test targets.
+- **No event bus / message dispatcher**: There is no central event routing system. Modules communicate via direct function calls (e.g., executor calls `oms.onExecution()` directly, strategies receive `L2Book` references directly). There is no pub/sub or event queue infrastructure.
+- **Mock/demo mode built into executors**: Both `SpotExecutor` and `FuturesExecutor` accept null client references and generate synthetic exchange IDs, meaning they can operate without live connections (`executor.zig:86-87,166-168`, `futures/executor.zig:139-141`)
+- **Thread utilities available**: `sdk/core/io/thread.zig` provides `pinToCore()` and `spawnPinned()` for CPU-affinity thread management (`thread.zig:6,37`)
+- **TCP available**: `sdk/core/io/tcp.zig` provides `TcpConnection.connect(allocator, host, port)` for network connections (`tcp.zig:10`)
+
+## Coverage gaps
+
+- 12 of 12 questions covered, 0 gaps.
+- Question 6 (terminal I/O primitives) is answered based on Zig stdlib knowledge rather than codebase files, since no TUI code exists yet. All other questions are answered with direct file:line references.

--- a/.claude/specs/trading-desk-tui/03-design-01.md
+++ b/.claude/specs/trading-desk-tui/03-design-01.md
@@ -1,0 +1,96 @@
+---
+phase: 3
+iteration: 01
+generated: 2026-04-03
+---
+
+# Design: Trading Desk TUI Application
+
+Research: .claude/specs/trading-desk-tui/02-research-01.md
+
+## Current State
+
+The codebase is a pure-Zig trading platform with a complete SDK layer and Kraken exchange integration, but **no application entry point** — `build.zig` contains zero `b.addExecutable` calls (research: build.zig has 972 lines, only test steps and modules). All code exists as libraries exercised through test targets.
+
+**Domain modules available for consumption:**
+- `L2Book` — sorted bid/ask arrays with O(1) BBO, `midPrice()`, `spread()` (research: `orderbook.zig:24-155`)
+- `OrderManager` — full order lifecycle with state machine, risk injection, event store injection (research: `oms.zig:171-289`)
+- `PositionManager` — FIFO/LIFO/avg cost basis tracking with realized/unrealized P&L (research: `positions.zig:64-257`)
+- `PreTradeRisk` — size, notional, position, rate, and price band checks (research: `pre_trade.zig:59-89`)
+- `SpotExecutor` / `FuturesExecutor` — exchange routing with built-in mock mode when all clients are null (research: `executor.zig:67-169`, `futures/executor.zig:69-142`)
+
+**Infrastructure available:**
+- `SpscRingBuffer(T)` — lock-free SPSC ring buffer with atomic acquire/release (research: `ring_buffer.zig:4-46`)
+- `MpscQueue(T)` — lock-free MPSC intrusive queue (research: `mpsc_queue.zig:5-66`)
+- `PoolAllocator` — fixed-slot slab with O(1) alloc/free (research: `memory.zig:6-90`)
+- `ArenaAllocator` — bump allocator with reset (research: `memory.zig:93-111`)
+- `spawnPinned` — CPU-affinity thread spawning (research: `thread.zig:37`)
+- `Timestamp` — monotonic and wall-clock time with RFC 3339 formatting (research: `time.zig:3-59`)
+- `EventLoop` — io_uring-based event loop, Linux-only, blocking (research: `event_loop.zig:21-102`)
+
+**No existing TUI code, no event bus, no central message dispatcher.** Modules communicate via direct function calls (research: cross-cutting observations).
+
+**VS Code workspace** exists but has no tasks.json or launch.json (research: `trading-platform.code-workspace:1-7`).
+
+## Desired End State
+
+A runnable trading desk terminal application at `trading/desk/main.zig` that:
+
+1. Launches into an alternate-screen TUI showing five panels: orderbook, positions, order entry, recent orders, and a status bar.
+2. Runs in demo mode out of the box with synthetic market data (no exchange credentials required).
+3. Allows the user to place, cancel, and view orders via keyboard interaction.
+4. Uses a dual-thread architecture: an engine thread driving market data and order management, and a TUI thread handling rendering and input.
+5. Provides VS Code tasks and debug configuration for build/run/test workflows.
+6. Is the **first executable target** in the repository's build system.
+
+## Patterns to Follow
+
+- **Allocator injection**: Every domain module accepts `std.mem.Allocator` as first parameter to `init()` (research: `orderbook.zig:24`, `oms.zig:183`, `positions.zig:64`, `pre_trade.zig:59`). The desk app will create allocators at the top level and inject them down.
+- **Init/deinit lifecycle**: All structs follow `init() !T` / `deinit(*T) void` (research: `orderbook.zig:24,159`, `oms.zig:183,289`). Every new struct in the desk will follow this pattern.
+- **Fixed-point i64 pricing**: All prices and quantities are `i64` throughout the codebase (research: cross-cutting observations). The TUI will format i64 to decimal for display (divide by 10^8 for Kraken's satoshi-scale prices).
+- **Null-client mock mode**: Both executors generate synthetic exchange IDs when all client refs are null (research: `executor.zig:86-87,166-168`, `futures/executor.zig:139-141`). Demo mode will pass null for all clients.
+- **SpscRingBuffer for cross-thread communication**: Lock-free, single-producer single-consumer, non-blocking push/pop (research: `ring_buffer.zig:4-46`). One buffer engine->TUI, one buffer TUI->engine.
+- **spawnPinned for thread management**: CPU-affinity thread spawning already in the codebase (research: `thread.zig:37`). Use for engine thread.
+- **Module graph wiring**: `b.createModule()` + `module.addImport()` for inter-module dependencies (research: `build.zig:80-100,108`).
+
+## Patterns to Avoid
+
+- **Direct function calls across threads**: The codebase uses direct calls (e.g., executor calls `oms.onExecution()` — research: `executor.zig:115-169`), but this is unsafe across threads. All cross-thread communication must go through the SpscRingBuffer.
+- **Shared mutable state**: The EventLoop uses a shared `read_buf: [65536]u8` (research: `event_loop.zig:27`). The desk will NOT share mutable buffers between threads — each thread owns its data.
+- **Raw u128 timestamps**: Some modules use raw `u128` nanoseconds instead of the `Timestamp` struct (research: `oms.zig:66`, `positions.zig:27`). The desk will use `Timestamp` from `time.zig` for all new time values and convert when interfacing with modules that use raw u128.
+- **EventLoop for stdin**: The EventLoop is designed for sockets with a single shared read buffer (research: `event_loop.zig:27`). The TUI thread will handle stdin directly via `std.posix.poll()` or blocking reads on its own thread, not through the EventLoop.
+
+## Resolved Design Decisions
+
+| Decision | Choice | Reason |
+| --- | --- | --- |
+| Architecture | Dual-thread (engine + TUI) | Clean separation of concerns; engine thread owns all domain state, TUI thread owns rendering. SpscRingBuffer provides lock-free communication. |
+| Thread communication | Two SpscRingBuffers (bidirectional) | Engine->TUI carries state snapshots; TUI->engine carries user commands. SPSC matches the exactly-two-thread model. |
+| TUI rendering | ANSI escape codes + raw terminal mode | Zero dependencies; alternate screen buffer for clean entry/exit. No external TUI library needed. |
+| Frame rate | Fixed 15 FPS default (configurable 10-20) | Trading data changes fast enough to warrant smooth updates, but no need for 60 FPS. ~66ms per frame is plenty for terminal rendering. |
+| Demo data generation | Synthetic random-walk orderbook + mock executors | Executors already support null-client mode. Synthetic market data generator produces realistic-looking L2Book updates. |
+| Layout | 5 panels: orderbook, positions, order entry, recent orders, status bar | Covers the core trading desk workflow: see market, see positions, place orders, track orders. |
+| Input model | Keyboard-driven: Tab between panels, arrows navigate, Enter submits | Terminal-native interaction. No mouse support needed for v1. |
+| File location | `trading/desk/main.zig` + supporting modules under `trading/desk/` | Follows monorepo convention with `trading/` as the application layer. |
+| Build integration | First `b.addExecutable` in build.zig + new build steps | `run-desk`, `build-desk`, `build-desk-release`, `test-desk` steps. |
+| VS Code integration | tasks.json + launch.json in `.vscode/` | Build, run, test tasks with Zig problem matchers; debug config for lldb. |
+| Price display | Format i64 as decimal with configurable precision | Default 2 decimal places for USD, 8 for BTC. Divide by scale factor. |
+| Terminal cleanup | Defer restore of terminal attributes + alternate screen exit | Ensures terminal is always restored on normal exit, panic, or Ctrl+C. |
+
+## Approach
+
+The trading desk is a two-thread application. The **engine thread** owns all domain state: L2Book instances, OrderManager, PositionManager, PreTradeRisk, and (in demo mode) a synthetic market data generator. It runs a tick loop that advances synthetic data, processes any incoming user commands from the TUI->engine ring buffer, and pushes state snapshots into the engine->TUI ring buffer. The engine thread uses `spawnPinned` for optional CPU affinity.
+
+The **TUI thread** runs on the main thread (the one that enters `main()`). It sets up raw terminal mode, switches to the alternate screen buffer, and enters a fixed-rate render loop. Each frame, it drains the engine->TUI ring buffer for the latest state snapshot, renders all five panels using ANSI escape codes written to a frame buffer (single `write()` call to stdout per frame to avoid flicker), reads any pending stdin bytes, parses key sequences, and pushes commands into the TUI->engine ring buffer. The frame loop sleeps to maintain the target FPS using `std.time.sleep()`.
+
+The **message protocol** between threads uses two tagged unions: `EngineEvent` (engine->TUI) carrying orderbook snapshots, position updates, order status changes, and connection status; and `UserCommand` (TUI->engine) carrying order submissions, cancellations, instrument selection, and quit signals. These are value types sized to fit in the SpscRingBuffer without heap allocation.
+
+**Demo mode** is the default and only mode for v1. A `SyntheticFeed` module generates random-walk price movements on a configurable set of instruments, applying them to L2Book instances. The SpotExecutor runs with null clients, generating synthetic fill responses. This means the desk is immediately runnable with `zig build run-desk` — no configuration, no API keys, no network.
+
+**Terminal management** is careful about cleanup. The TUI stores the original termios attributes on startup and defers restoration. A signal handler for SIGINT/SIGTERM ensures the alternate screen is exited and terminal is restored even on abrupt shutdown. The renderer uses a single write buffer per frame — it builds the entire screen in memory, then writes it in one syscall to minimize flicker.
+
+**Build system changes** add the first `b.addExecutable` target to `build.zig`, creating a `desk` executable that imports SDK modules (orderbook, oms, positions, risk, memory, time, containers, thread) and builds from `trading/desk/main.zig`. Four new build steps are added: `run-desk`, `build-desk`, `build-desk-release`, `test-desk`.
+
+## Open Questions
+
+(None — all design decisions resolved.)

--- a/.claude/specs/trading-desk-tui/04-outline-01.md
+++ b/.claude/specs/trading-desk-tui/04-outline-01.md
@@ -1,0 +1,250 @@
+---
+phase: 4
+iteration: 01
+generated: 2026-04-03
+---
+
+# Outline: Trading Desk TUI Application
+
+Design: .claude/specs/trading-desk-tui/03-design-01.md
+
+## Overview
+
+Build the first executable target in the trading platform monorepo — a terminal-based trading desk in pure Zig. The implementation proceeds in seven vertical slices: (1) build system + minimal executable, (2) terminal management, (3) rendering framework with panel layout, (4) dual-thread engine with ring buffer communication, (5) domain integration with synthetic data, (6) keyboard input and order entry, (7) VS Code developer tooling. Each phase produces a runnable binary that demonstrates incremental progress.
+
+---
+
+## Phase 1: Build System and Minimal Executable
+**Delivers**: A `zig build run-desk` command that compiles and runs a "hello world" binary from `trading/desk/main.zig`
+**Layers touched**: build.zig, trading/desk/main.zig
+
+### Key types / signatures introduced
+```zig
+// trading/desk/main.zig
+pub fn main() !void
+```
+
+### Build system additions
+- `b.addExecutable(.{ .name = "desk", .root_source_file = b.path("trading/desk/main.zig") })` — first executable target in the repo
+- Build steps: `run-desk`, `build-desk`, `build-desk-release`, `test-desk`
+- Wire SDK module imports (orderbook, oms, positions, risk, memory, time, containers, thread) for use in later phases
+
+### Test checkpoint
+- Type: Automated
+- `zig build run-desk` prints a message and exits 0
+- `zig build test-desk` passes (empty test block)
+
+---
+
+## Phase 2: Terminal Management
+**Delivers**: Binary enters raw mode, switches to alternate screen, displays a static message, waits for 'q' keypress, then cleanly restores the terminal
+**Layers touched**: trading/desk/terminal.zig, trading/desk/main.zig
+**Depends on**: Phase 1
+
+### Key types / signatures introduced
+```zig
+// trading/desk/terminal.zig
+pub const Terminal = struct {
+    pub fn init() !Terminal               // tcgetattr, set raw mode, enter alternate screen
+    pub fn deinit(self: *Terminal) void    // restore original termios, exit alternate screen
+    pub fn getSize() !Size                // ioctl TIOCGWINSZ
+    pub fn readByte(self: *Terminal) ?u8   // non-blocking stdin read via poll()
+    pub fn writer(self: *Terminal) Writer  // stdout writer
+};
+pub const Size = struct { rows: u16, cols: u16 };
+```
+
+### Test checkpoint
+- Type: Manual
+- `zig build run-desk` enters alternate screen, shows "Trading Desk — press q to quit", pressing 'q' exits cleanly with terminal restored
+- `zig build test-desk` passes unit tests for Terminal (test raw mode flag manipulation on a mock fd)
+
+---
+
+## Phase 3: Rendering Framework and Panel Layout
+**Delivers**: Binary renders a five-panel layout with box-drawing borders and placeholder text at a fixed frame rate, resizable with terminal
+**Layers touched**: trading/desk/renderer.zig, trading/desk/layout.zig, trading/desk/main.zig
+**Depends on**: Phase 2
+
+### Key types / signatures introduced
+```zig
+// trading/desk/renderer.zig
+pub const Renderer = struct {
+    pub fn init(allocator: std.mem.Allocator, terminal: *Terminal) !Renderer
+    pub fn deinit(self: *Renderer) void
+    pub fn beginFrame(self: *Renderer) void           // reset frame buffer
+    pub fn drawBox(self: *Renderer, rect: Rect, title: []const u8) void
+    pub fn drawText(self: *Renderer, x: u16, y: u16, text: []const u8) void
+    pub fn drawTextFmt(self: *Renderer, x: u16, y: u16, comptime fmt: []const u8, args: anytype) void
+    pub fn endFrame(self: *Renderer) !void             // single write() to stdout
+};
+pub const Rect = struct { x: u16, y: u16, w: u16, h: u16 };
+
+// trading/desk/layout.zig
+pub const Layout = struct {
+    pub fn compute(terminal_size: Size) Panels
+};
+pub const Panels = struct {
+    orderbook: Rect,
+    positions: Rect,
+    order_entry: Rect,
+    recent_orders: Rect,
+    status_bar: Rect,
+};
+```
+
+### Test checkpoint
+- Type: Manual + Automated
+- `zig build run-desk` displays five bordered panels with placeholder titles at ~15 FPS; resizing the terminal reflows the layout; 'q' exits cleanly
+- `zig build test-desk` passes unit tests for Layout.compute (given known Size, verify Rect positions) and Renderer buffer logic
+
+---
+
+## Phase 4: Engine Thread and Ring Buffer Communication
+**Delivers**: Dual-thread architecture running — engine thread sends tick counter via SpscRingBuffer, TUI thread displays it in the status bar, proving cross-thread communication works
+**Layers touched**: trading/desk/engine.zig, trading/desk/messages.zig, trading/desk/main.zig
+**Depends on**: Phase 3
+
+### Key types / signatures introduced
+```zig
+// trading/desk/messages.zig
+pub const EngineEvent = union(enum) {
+    tick: u64,
+    orderbook_snapshot: OrderbookSnapshot,
+    position_update: PositionUpdate,
+    order_update: OrderUpdate,
+    status: StatusUpdate,
+    shutdown_ack: void,
+};
+pub const UserCommand = union(enum) {
+    quit: void,
+    select_instrument: []const u8,
+    submit_order: OrderRequest,
+    cancel_order: u64,
+};
+pub const OrderbookSnapshot = struct { ... };
+pub const PositionUpdate = struct { ... };
+pub const OrderUpdate = struct { ... };
+pub const OrderRequest = struct { ... };
+pub const StatusUpdate = struct { ... };
+
+// trading/desk/engine.zig
+pub const Engine = struct {
+    pub fn init(allocator: std.mem.Allocator, to_tui: *RingBuffer(EngineEvent), from_tui: *RingBuffer(UserCommand)) !Engine
+    pub fn deinit(self: *Engine) void
+    pub fn run(self: *Engine) void    // entry point for engine thread; loops until quit
+};
+```
+
+### Test checkpoint
+- Type: Manual + Automated
+- `zig build run-desk` shows a live tick counter incrementing in the status bar (proves engine thread is running and ring buffer is delivering events)
+- `zig build test-desk` passes unit tests for message serialization and Engine init/deinit
+
+---
+
+## Phase 5: Domain Integration and Synthetic Data
+**Delivers**: Live demo mode — orderbook panel shows moving bid/ask levels, positions panel shows holdings, recent orders panel shows order history, all driven by synthetic data from the engine thread
+**Layers touched**: trading/desk/engine.zig, trading/desk/synthetic.zig, trading/desk/panels/*.zig, trading/desk/main.zig
+**Depends on**: Phase 4
+
+### Key types / signatures introduced
+```zig
+// trading/desk/synthetic.zig
+pub const SyntheticFeed = struct {
+    pub fn init(allocator: std.mem.Allocator, instruments: []const []const u8) !SyntheticFeed
+    pub fn deinit(self: *SyntheticFeed) void
+    pub fn tick(self: *SyntheticFeed) void    // advance prices by one random-walk step
+    pub fn getBook(self: *SyntheticFeed, instrument: []const u8) ?*const L2Book
+};
+
+// trading/desk/panels/orderbook_panel.zig
+pub fn draw(renderer: *Renderer, rect: Rect, snapshot: *const OrderbookSnapshot) void
+
+// trading/desk/panels/positions_panel.zig
+pub fn draw(renderer: *Renderer, rect: Rect, positions: []const PositionUpdate) void
+
+// trading/desk/panels/orders_panel.zig
+pub fn draw(renderer: *Renderer, rect: Rect, orders: []const OrderUpdate) void
+
+// trading/desk/panels/status_panel.zig
+pub fn draw(renderer: *Renderer, rect: Rect, status: *const StatusUpdate) void
+```
+
+### Engine integration
+- Engine.init wires up: L2Book, OrderManager, PositionManager, PreTradeRisk, SpotExecutor (null clients)
+- Engine.run loop: SyntheticFeed.tick() -> snapshot L2Book -> push EngineEvent.orderbook_snapshot
+- Instruments: BTC-USD, ETH-USD (hardcoded for demo)
+
+### Test checkpoint
+- Type: Manual + Automated
+- `zig build run-desk` shows a live orderbook with moving prices, position panel, and order history — all synthetic
+- `zig build test-desk` passes unit tests for SyntheticFeed (deterministic seed produces expected price sequence) and panel draw functions (verify output contains expected content)
+
+---
+
+## Phase 6: Input Handling and Order Entry
+**Delivers**: Full interactive trading desk — user can Tab between panels, type in the order entry form, submit orders with Enter, cancel orders, and switch instruments
+**Layers touched**: trading/desk/input.zig, trading/desk/panels/order_entry_panel.zig, trading/desk/main.zig, trading/desk/engine.zig
+**Depends on**: Phase 5
+
+### Key types / signatures introduced
+```zig
+// trading/desk/input.zig
+pub const InputHandler = struct {
+    pub fn init() InputHandler
+    pub fn feed(self: *InputHandler, byte: u8) ?Action
+};
+pub const Action = union(enum) {
+    tab: void,
+    shift_tab: void,
+    arrow_up: void,
+    arrow_down: void,
+    enter: void,
+    escape: void,
+    char: u8,
+    backspace: void,
+    quit: void,          // Ctrl+C or 'q' when not in text field
+};
+
+// trading/desk/panels/order_entry_panel.zig
+pub const OrderEntryPanel = struct {
+    pub fn init() OrderEntryPanel
+    pub fn handleAction(self: *OrderEntryPanel, action: Action) ?UserCommand
+    pub fn draw(self: *const OrderEntryPanel, renderer: *Renderer, rect: Rect, active: bool) void
+};
+```
+
+### Test checkpoint
+- Type: Manual + Automated
+- `zig build run-desk` — user can Tab to order entry, type quantity/price, press Enter to submit; order appears in recent orders panel with status updates from mock executor
+- `zig build test-desk` passes unit tests for InputHandler (byte sequences map to correct Actions) and OrderEntryPanel (action sequences produce correct UserCommands)
+
+---
+
+## Phase 7: VS Code Integration
+**Delivers**: VS Code tasks.json and launch.json for build, run, test, and debug workflows
+**Layers touched**: .vscode/tasks.json, .vscode/launch.json
+**Depends on**: Phase 1 (build steps must exist)
+
+### Files created
+```jsonc
+// .vscode/tasks.json — tasks: Build Desk, Build Desk (Release), Run Desk, Test Desk
+// .vscode/launch.json — debug config: Debug Desk (lldb, desk executable)
+```
+
+### Test checkpoint
+- Type: Manual
+- Open VS Code, run "Build Desk" task (Ctrl+Shift+B), verify it compiles
+- Run "Debug Desk" launch config (F5), verify breakpoints work in main.zig
+
+---
+
+## Dependencies
+
+- Phase 2 depends on Phase 1: needs the executable target and build steps to exist
+- Phase 3 depends on Phase 2: needs Terminal for raw mode and stdout writer
+- Phase 4 depends on Phase 3: needs Renderer and Layout to display engine output
+- Phase 5 depends on Phase 4: needs Engine thread and ring buffer to deliver domain data
+- Phase 6 depends on Phase 5: needs live domain state to make input meaningful (placing orders against the synthetic orderbook)
+- Phase 7 is independent of Phases 2-6 (only needs Phase 1 build steps) but is sequenced last because it is lowest priority and benefits from the final build step names being stable

--- a/.claude/specs/trading-desk-tui/05-plan-01.md
+++ b/.claude/specs/trading-desk-tui/05-plan-01.md
@@ -1,0 +1,327 @@
+---
+phase: 5
+iteration: 01
+generated: 2026-04-03
+---
+
+# Implementation Plan: Trading Desk TUI Application
+
+Design: .claude/specs/trading-desk-tui/03-design-01.md
+Outline: .claude/specs/trading-desk-tui/04-outline-01.md
+
+---
+
+## Phase 1: Build System and Minimal Executable
+
+### Overview
+Add the first executable target to the repository. Create `trading/desk/main.zig` with a minimal `pub fn main() !void` that prints a startup message and exits. Wire it into `build.zig` with build steps `run-desk`, `build-desk`, `build-desk-release`, and `test-desk`. Define reusable build modules for SDK core modules (memory, time, ring_buffer, thread) that don't yet have module definitions.
+
+### Changes
+
+#### `trading/desk/main.zig` — NEW
+- Minimal entry point: `pub fn main() !void` that writes "Trading Desk v0.1.0" to stdout and returns
+- Include an empty test block: `test "desk_smoke" { }` for the test-desk step
+
+#### `build.zig` — Add executable target and build steps (append before closing `}`)
+- Create build modules for SDK core files not yet modularized:
+  - `memory_mod = b.createModule(.{ .root_source_file = b.path("sdk/core/memory.zig") })`
+  - `time_mod = b.createModule(.{ .root_source_file = b.path("sdk/core/time.zig") })`
+  - `ring_buffer_mod = b.createModule(.{ .root_source_file = b.path("sdk/core/containers/ring_buffer.zig") })`
+  - `thread_mod = b.createModule(.{ .root_source_file = b.path("sdk/core/io/thread.zig") })`
+- Create the desk module: `desk_mod = b.createModule(.{ .root_source_file = b.path("trading/desk/main.zig") })`
+- Wire imports into desk_mod: `orderbook` (use existing `orderbook_mod`), `oms`, `order_types`, `positions`, `pre_trade`, `memory`, `time`, `ring_buffer`, `thread`
+- Add executable: `b.addExecutable(.{ .name = "desk", .root_module = desk_mod, .target = target, .optimize = optimize })`
+- Add `b.installArtifact(desk_exe)` for the install step
+- Add 4 build steps:
+  - `build-desk` — depends on desk_exe compile step
+  - `build-desk-release` — same executable with `.optimize = .ReleaseFast` override (or document using `-Doptimize=ReleaseFast`)
+  - `run-desk` — `b.addRunArtifact(desk_exe)`, depends on compile
+  - `test-desk` — `b.addTest` on `trading/desk/main.zig` with same module imports, add to `test_step` as well
+- Note: `build-desk-release` can simply be documented as `zig build build-desk -Doptimize=ReleaseFast` rather than a separate step, since `standardOptimizeOption` already handles this. Add a comment in build.zig.
+
+### Edge cases
+- Module name collisions: the existing `orderbook_mod` at line 827 vs `orderbook_mod_p12` at line 740. Use the line-827 definition (it's the canonical one used by executor tests).
+- The `_ = risk_stress_mod;` at line 160 suggests unused modules exist; do not remove them.
+
+### Breaking changes
+- None. This is purely additive.
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build run-desk`
+- expected-output: `Trading Desk v0.1.0`
+
+---
+
+## Phase 2: Terminal Management
+
+### Overview
+Implement raw terminal mode, alternate screen buffer management, terminal size detection, and non-blocking stdin reading. The binary enters alternate screen on start, shows a static message, reads a 'q' keypress to quit, and cleanly restores the terminal on exit.
+
+### Changes
+
+#### `trading/desk/terminal.zig` — NEW
+- `pub const Size = struct { rows: u16, cols: u16 };`
+- `pub const Terminal = struct { ... }` with fields:
+  - `original_termios: std.posix.termios` — saved on init for restore
+  - `stdin_fd: std.posix.fd_t` — stdin file descriptor
+  - `stdout: std.fs.File` — stdout file
+  - `buf_writer: std.io.BufferedWriter(4096, std.fs.File.Writer)` — buffered stdout
+- `pub fn init() !Terminal` — calls `tcgetattr` to save original, sets raw mode (disable `ICANON`, `ECHO`, `ISIG`, `IEXTEN`; disable `IXON`, `ICRNL` in iflag; set `CS8` in cflag; set VMIN=0, VTIME=0 for non-blocking), writes `\x1b[?1049h` (enter alternate screen) + `\x1b[?25l` (hide cursor)
+- `pub fn deinit(self: *Terminal) void` — writes `\x1b[?25h` (show cursor) + `\x1b[?1049l` (exit alternate screen), calls `tcsetattr` to restore original_termios
+- `pub fn getSize() !Size` — `ioctl(stdout_fd, TIOCGWINSZ, &winsize)`, return `.{ .rows = ws.ws_row, .cols = ws.ws_col }`
+- `pub fn readByte(self: *Terminal) ?u8` — use `std.posix.poll` on stdin_fd with timeout 0ms; if ready, read 1 byte; return null if nothing available
+- `pub fn writer(self: *Terminal) *std.io.BufferedWriter(4096, std.fs.File.Writer)` — return pointer to buf_writer
+- `pub fn flush(self: *Terminal) !void` — flush the buffered writer
+- Signal handling: register a SIGINT/SIGTERM handler via `std.posix.sigaction` that sets a global `volatile bool` flag; main loop checks this flag alongside 'q' keypress
+
+#### `trading/desk/main.zig` — Update
+- Import `terminal` module (relative import `@import("terminal.zig")`)
+- In `main()`: init Terminal (defer deinit), enter loop that calls `readByte()`, break on 'q' or signal flag, sleep 16ms per iteration
+- Display static text: "Trading Desk v0.1.0 -- press q to quit" at row 2, col 2 using escape sequence `\x1b[2;2H`
+
+### Edge cases
+- Terminal restore on panic: use `@import("builtin").panic` override or rely on the deferred deinit (Zig's defer runs on normal return but not on panic; add a note that panic won't restore — acceptable for v1)
+- Non-terminal stdin (piped input): `tcgetattr` will fail; detect this and fall back to a non-raw mode with a warning
+- Very small terminals: getSize returning < 10 rows or < 40 cols; clamp to minimum
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build test-desk`
+- expected-output: `All 1 tests passed`
+
+---
+
+## Phase 3: Rendering Framework and Panel Layout
+
+### Overview
+Build a frame-buffer renderer that constructs the entire screen in memory and writes it in a single syscall. Implement a layout engine that divides the terminal into five panels (orderbook, positions, order entry, recent orders, status bar). The binary renders bordered panels with placeholder titles at ~15 FPS.
+
+### Changes
+
+#### `trading/desk/layout.zig` — NEW
+- `pub const Rect = struct { x: u16, y: u16, w: u16, h: u16 };`
+- `pub const Panels = struct { orderbook: Rect, positions: Rect, order_entry: Rect, recent_orders: Rect, status_bar: Rect };`
+- `pub fn compute(size: Terminal.Size) Panels` — divide terminal: top half split 50/50 (orderbook left, positions right), bottom half minus 1 row split 50/50 (order entry left, recent orders right), bottom row is status bar. Minimum sizes: 80x24.
+
+#### `trading/desk/renderer.zig` — NEW
+- `pub const Renderer = struct { ... }` with fields:
+  - `allocator: std.mem.Allocator`
+  - `buf: []u8` — frame buffer, sized to `rows * cols * 4` (account for ANSI sequences)
+  - `cursor: usize` — write cursor into buf
+  - `terminal: *Terminal`
+- `pub fn init(allocator: std.mem.Allocator, terminal: *Terminal) !Renderer`
+- `pub fn deinit(self: *Renderer) void` — free buf
+- `pub fn beginFrame(self: *Renderer) void` — reset cursor to 0, write `\x1b[H` (cursor home) to buf
+- `pub fn drawBox(self: *Renderer, rect: Rect, title: []const u8) void` — write box-drawing chars (`+`, `-`, `|`) at rect boundaries with title centered on top border
+- `pub fn drawText(self: *Renderer, x: u16, y: u16, text: []const u8) void` — write `\x1b[{y};{x}H{text}` to buf
+- `pub fn drawTextFmt(self: *Renderer, x: u16, y: u16, comptime fmt: []const u8, args: anytype) void` — same with formatting
+- `pub fn endFrame(self: *Renderer) !void` — single `terminal.writer().writeAll(buf[0..cursor])` then `terminal.flush()`
+- `pub fn resize(self: *Renderer, new_size: Terminal.Size) !void` — reallocate buf if needed
+
+#### `trading/desk/main.zig` — Update
+- Create Renderer, compute Layout each frame (handles resize), render 5 bordered panels with placeholder titles ("Orderbook", "Positions", "Order Entry", "Recent Orders"), status bar shows "Trading Desk v0.1.0 | q=quit"
+- Frame loop: `beginFrame` -> `drawBox` for each panel -> `endFrame` -> check input -> `std.time.sleep(66_000_000)` (15 FPS)
+- On terminal resize (SIGWINCH or size change detected): recompute layout, reallocate renderer if needed
+
+### Edge cases
+- Frame buffer overflow: size buf conservatively (rows * cols * 12 bytes to account for escape sequences); assert cursor never exceeds buf.len
+- Zero-width or zero-height panels when terminal is too small: clamp minimum terminal size to 80x24, skip rendering panels that don't fit
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build test-desk`
+- expected-output: `All 1 tests passed`
+
+---
+
+## Phase 4: Engine Thread and Ring Buffer Communication
+
+### Overview
+Split into dual-thread architecture. The engine thread runs in a loop, sending tick events through a SpscRingBuffer to the TUI thread. The TUI thread drains events and displays tick count in the status bar. This proves the cross-thread communication pipeline works before adding domain logic.
+
+### Changes
+
+#### `trading/desk/messages.zig` — NEW
+- Define message types for the ring buffers:
+- `pub const EngineEvent = union(enum) { tick: u64, orderbook_snapshot: OrderbookSnapshot, position_update: PositionUpdate, order_update: OrderUpdate, status: StatusUpdate, shutdown_ack: void };`
+- `pub const UserCommand = union(enum) { quit: void, select_instrument: InstrumentId, submit_order: OrderRequest, cancel_order: u64 };`
+- `pub const InstrumentId = struct { buf: [32]u8, len: u8 }` — fixed-size instrument name to avoid heap allocation in ring buffer
+- `pub const OrderbookSnapshot = struct { instrument: InstrumentId, bids: [20]PriceLevel, asks: [20]PriceLevel, bid_count: u8, ask_count: u8 }` — fixed-size snapshot (20 levels max)
+- `pub const PriceLevel = struct { price: i64, quantity: i64 }`
+- `pub const PositionUpdate = struct { instrument: InstrumentId, quantity: i64, avg_cost: i64, unrealized_pnl: i64, realized_pnl: i64 }`
+- `pub const OrderUpdate = struct { id: u64, instrument: InstrumentId, side: u8, quantity: i64, price: i64, status: u8, filled_qty: i64 }`
+- `pub const OrderRequest = struct { instrument: InstrumentId, side: u8, quantity: i64, price: i64 }`
+- `pub const StatusUpdate = struct { tick: u64, engine_time_ns: u128, instrument_count: u8, connected: bool }`
+- All types are value types with fixed sizes — no pointers, no slices — safe for SpscRingBuffer
+
+#### `trading/desk/engine.zig` — NEW
+- `pub const Engine = struct { ... }` with fields:
+  - `allocator: std.mem.Allocator`
+  - `to_tui: *SpscRingBuffer(EngineEvent)` — engine pushes events here
+  - `from_tui: *SpscRingBuffer(UserCommand)` — engine pops commands here
+  - `running: bool`
+  - `tick: u64`
+- `pub fn init(allocator: std.mem.Allocator, to_tui: *SpscRingBuffer(EngineEvent), from_tui: *SpscRingBuffer(UserCommand)) !Engine`
+- `pub fn deinit(self: *Engine) void`
+- `pub fn run(self: *Engine) void` — loop: increment tick, push `EngineEvent{ .tick = self.tick }`, drain from_tui for quit command, sleep 100ms per tick. Sets `running = false` on quit.
+- `pub fn requestStop(self: *Engine) void` — sets running = false (called from TUI thread via atomic or ring buffer quit command)
+
+#### `trading/desk/main.zig` — Update
+- Allocate two SpscRingBuffers: `to_tui: SpscRingBuffer(EngineEvent)` and `from_tui: SpscRingBuffer(UserCommand)`, capacity 256
+- Spawn engine thread via `std.Thread.spawn` (use spawnPinned if available, fall back to std.Thread.spawn)
+- TUI main loop: drain `to_tui` ring buffer each frame, update local state (tick count), render
+- On 'q' keypress: push `UserCommand.quit` into `from_tui`, wait for engine thread to join
+- Status bar shows: "Tick: {N} | q=quit"
+
+### Edge cases
+- Ring buffer full: engine's `push` returns false; drop the event (acceptable for status ticks, log a counter of dropped events)
+- Engine thread panic: TUI thread should detect engine stopped (no ticks for N frames) and show "Engine stopped" in status bar
+- Shutdown ordering: TUI sends quit command, engine ACKs with shutdown_ack event, TUI waits for thread join with timeout
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build test-desk`
+- expected-output: `All 1 tests passed`
+
+---
+
+## Phase 5: Domain Integration and Synthetic Data
+
+### Overview
+Wire up the real SDK domain modules (L2Book, OrderManager, PositionManager, PreTradeRisk, SpotExecutor) inside the engine thread. Add a synthetic market data feed that generates random-walk price movements. The TUI now shows live orderbook data, positions, and order history — all driven by synthetic data.
+
+### Changes
+
+#### `trading/desk/synthetic.zig` — NEW
+- `pub const SyntheticFeed = struct { ... }` with fields:
+  - `allocator: std.mem.Allocator`
+  - `books: [2]L2Book` — one per instrument (BTC-USD, ETH-USD)
+  - `rng: std.Random.DefaultPrng` — seeded from timestamp for variety
+  - `tick_count: u64`
+- `pub fn init(allocator: std.mem.Allocator, seed: u64) !SyntheticFeed` — init two L2Books with depth 20, populate initial snapshots with realistic starting prices (BTC ~50000.00000000 in i64 = 5_000_000_000_000, ETH ~3000.00000000 = 300_000_000_000)
+- `pub fn deinit(self: *SyntheticFeed) void` — deinit both books
+- `pub fn tick(self: *SyntheticFeed) void` — for each book: generate random delta (-1 to +1 in smallest price increment), call `applyUpdate` on 1-3 random levels per side; occasionally (1 in 20 ticks) shift entire book by a larger amount
+- `pub fn getBook(self: *SyntheticFeed, index: usize) *const L2Book` — return const pointer to book
+
+#### `trading/desk/panels/orderbook_panel.zig` — NEW
+- `pub fn draw(renderer: *Renderer, rect: Rect, snapshot: *const OrderbookSnapshot) void` — render bid/ask columns: price | qty for asks (top-down, red), spread line, price | qty for bids (top-down, green). Use ANSI colors: `\x1b[32m` green for bids, `\x1b[31m` red for asks, `\x1b[0m` reset. Format i64 prices as decimal with 2 decimal places (divide by 100_000_000, show 2 decimals for USD display).
+
+#### `trading/desk/panels/positions_panel.zig` — NEW
+- `pub fn draw(renderer: *Renderer, rect: Rect, positions: []const PositionUpdate) void` — table: Instrument | Qty | Avg Cost | Unrealized P&L | Realized P&L. Color P&L green/red.
+
+#### `trading/desk/panels/orders_panel.zig` — NEW
+- `pub fn draw(renderer: *Renderer, rect: Rect, orders: []const OrderUpdate) void` — table: ID | Instrument | Side | Qty | Price | Status | Filled. Most recent orders first. Max ~10 visible rows.
+
+#### `trading/desk/panels/status_panel.zig` — NEW
+- `pub fn draw(renderer: *Renderer, rect: Rect, status: *const StatusUpdate) void` — single row: "BTC-USD | Tick: {N} | {HH:MM:SS} | Demo Mode"
+
+#### `trading/desk/engine.zig` — Update
+- Add fields: `feed: SyntheticFeed`, `oms: OrderManager`, `positions: PositionManager`, `risk: PreTradeRisk`, `executor: SpotExecutor`
+- In `init()`: create all domain objects. For OrderManager, provide risk_validate_fn and store_append_fn as simple function pointers (risk validates via PreTradeRisk, store is a no-op for demo). SpotExecutor gets null for all client refs (mock mode).
+- In `run()` loop: call `feed.tick()`, snapshot each book into `OrderbookSnapshot` (copy top 20 levels), push `EngineEvent.orderbook_snapshot`. Push `EngineEvent.position_update` for each active position. Push `EngineEvent.status` with current tick/time.
+- Process `UserCommand.submit_order`: translate OrderRequest to OMS Order, call `oms.submitOrder()`, then `executor.placeOrder()`, push `EngineEvent.order_update` with result.
+- Process `UserCommand.cancel_order`: call `oms.cancelOrder()`, push order update.
+- Every N ticks, generate a synthetic fill on existing orders to simulate execution (call `executor.processExecutionReport` and `positions.onFill`).
+
+#### `trading/desk/main.zig` — Update
+- TUI frame loop: drain all EngineEvents, update local arrays (latest orderbook snapshot per instrument, position list, order list, status)
+- Call each panel draw function with the appropriate data
+- Track "active instrument" index for which orderbook to display
+
+### Edge cases
+- L2Book with no levels: SyntheticFeed must always populate at least 5 levels per side on init
+- OrderManager risk rejection: display rejected status in orders panel (the OMS already handles this via ValidationResult)
+- Ring buffer full with orderbook snapshots: engine drops oldest; TUI always shows latest (drain all, keep last)
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build test-desk`
+- expected-output: `All 1 tests passed`
+
+---
+
+## Phase 6: Input Handling and Order Entry
+
+### Overview
+Add full keyboard input handling: Tab cycles between panels, arrow keys navigate within panels, the order entry panel accepts text input for quantity and price, Enter submits orders. The desk is now fully interactive.
+
+### Changes
+
+#### `trading/desk/input.zig` — NEW
+- `pub const Action = union(enum) { tab: void, shift_tab: void, arrow_up: void, arrow_down: void, arrow_left: void, arrow_right: void, enter: void, escape: void, char: u8, backspace: void, quit: void, delete_line: void };`
+- `pub const InputHandler = struct { ... }` with fields:
+  - `state: State` — enum: `normal`, `escape`, `escape_bracket` for parsing multi-byte escape sequences
+  - `seq_buf: [8]u8` — accumulate escape sequence bytes
+  - `seq_len: u8`
+- `pub fn init() InputHandler`
+- `pub fn feed(self: *InputHandler, byte: u8) ?Action` — state machine: byte 0x1b enters escape state, `[` enters escape_bracket, then parse arrow keys (`A`=up, `B`=down, `C`=right, `D`=left), `Z`=shift-tab. Ctrl+C or 'q' in normal mode (when not in text field) = quit. Byte 0x7f or 0x08 = backspace. 0x0d = enter. Printable ASCII (0x20-0x7e) = char.
+
+#### `trading/desk/panels/order_entry_panel.zig` — NEW
+- `pub const OrderEntryPanel = struct { ... }` with fields:
+  - `fields: [4]TextField` — instrument, side (buy/sell toggle), quantity, price
+  - `active_field: u8` — 0-3 index
+  - `side: u8` — 0=buy, 1=sell
+- `pub const TextField = struct { buf: [32]u8, len: u8, cursor: u8 }`
+- `pub fn init(default_instrument: []const u8) OrderEntryPanel` — pre-fill instrument field
+- `pub fn handleAction(self: *OrderEntryPanel, action: Action) ?UserCommand` — arrow_up/down cycles active_field, char/backspace edits current field, enter on price field constructs and returns UserCommand.submit_order, tab returns null (handled by main for panel switching)
+- `pub fn draw(self: *const OrderEntryPanel, renderer: *Renderer, rect: Rect, active: bool) void` — draw field labels and values, highlight active field with inverse video `\x1b[7m`, show cursor in active text field
+
+#### `trading/desk/main.zig` — Update
+- Add `active_panel: u8` (0=orderbook, 1=positions, 2=order_entry, 3=recent_orders)
+- Tab increments active_panel mod 4, shift-tab decrements
+- Route Actions to active panel: if active_panel==2, send to OrderEntryPanel.handleAction; if result is a UserCommand, push to from_tui ring buffer
+- Arrow keys in orderbook panel: scroll through levels (if more than visible area)
+- Arrow keys in orders panel: scroll through order history
+- Draw active panel border with highlight color (`\x1b[1m` bold or `\x1b[36m` cyan)
+- 'q' only quits when active_panel != 2 (order entry); in order entry, 'q' is a char input. Escape exits order entry focus.
+
+### Edge cases
+- Partial escape sequences: if terminal sends `\x1b` then nothing more within 50ms, treat as Escape key (timeout in InputHandler state machine — use frame boundary as implicit timeout: if state is `escape` and no byte arrives next frame, emit escape action)
+- Text field overflow: reject chars when TextField.len reaches 31
+- Invalid price/quantity: parse as integer on submit; if parse fails, flash the status bar with "Invalid input" and don't submit
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && zig build test-desk`
+- expected-output: `All 1 tests passed`
+
+---
+
+## Phase 7: VS Code Integration
+
+### Overview
+Create VS Code tasks.json and launch.json for build, run, test, and debug workflows. This is the final phase — purely configuration, no Zig code changes.
+
+### Changes
+
+#### `.vscode/tasks.json` — NEW
+- Four tasks:
+  1. `Build Desk` — command: `zig build build-desk`, group: build, problemMatcher: `$gcc` (works for Zig errors)
+  2. `Build Desk (Release)` — command: `zig build build-desk -Doptimize=ReleaseFast`
+  3. `Run Desk` — command: `zig build run-desk`, presentation: { reveal: always, panel: new }
+  4. `Test Desk` — command: `zig build test-desk`, group: test, problemMatcher: `$gcc`
+
+#### `.vscode/launch.json` — NEW
+- One launch configuration:
+  - `Debug Desk` — type: `lldb`, request: `launch`, program: `${workspaceFolder}/zig-out/bin/desk`, preLaunchTask: `Build Desk`, cwd: `${workspaceFolder}`
+
+### Edge cases
+- Users without CodeLLDB extension: add a comment in launch.json noting the dependency
+- Path differences: use `${workspaceFolder}` for all paths
+
+### Breaking changes
+- None
+
+### Test checkpoint
+- command: `cd /home/christian/git/trading-platform && cat .vscode/tasks.json | head -1`
+- expected-output: `{`

--- a/.claude/specs/trading-desk-tui/06-worktree-01.md
+++ b/.claude/specs/trading-desk-tui/06-worktree-01.md
@@ -1,0 +1,39 @@
+---
+phase: 6
+iteration: 01
+generated: 2026-04-03
+---
+
+# Worktree Plan: Trading Desk TUI Application
+
+Plan: .claude/specs/trading-desk-tui/05-plan-01.md
+
+## Dependency Analysis
+
+All 7 plan phases share `trading/desk/main.zig` (modified in every phase) and `build.zig` (modified in Phase 1). Each phase depends on the output of the previous phase. No parallelism is possible.
+
+| Phase | Files modified |
+| --- | --- |
+| Phase 1 | `trading/desk/main.zig` (NEW), `build.zig` |
+| Phase 2 | `trading/desk/terminal.zig` (NEW), `trading/desk/main.zig` |
+| Phase 3 | `trading/desk/layout.zig` (NEW), `trading/desk/renderer.zig` (NEW), `trading/desk/main.zig` |
+| Phase 4 | `trading/desk/messages.zig` (NEW), `trading/desk/engine.zig` (NEW), `trading/desk/main.zig` |
+| Phase 5 | `trading/desk/synthetic.zig` (NEW), `trading/desk/panels/*.zig` (NEW), `trading/desk/engine.zig`, `trading/desk/main.zig` |
+| Phase 6 | `trading/desk/input.zig` (NEW), `trading/desk/panels/order_entry_panel.zig` (NEW), `trading/desk/main.zig` |
+| Phase 7 | `.vscode/tasks.json` (NEW), `.vscode/launch.json` (NEW) |
+
+## Batch 1 (sequential — all phases)
+
+### Worktree 1
+- Branch: `trading-desk-tui-01-01`
+- Path: `.worktrees/trading-desk-tui-01`
+- Phases: 1, 2, 3, 4, 5, 6, 7 (all sequential)
+- Can start: immediately
+
+## Merge order
+1. Complete all 7 phases sequentially in `trading-desk-tui-01-01`
+2. Create PR to merge `trading-desk-tui-01-01` into `main`
+
+## Implementation prompt for Phase 7
+
+/spec.07.implement .claude/specs/trading-desk-tui/05-plan-01.md .claude/specs/trading-desk-tui/06-worktree-01.md

--- a/.claude/specs/trading-desk-tui/07-implementation-01.md
+++ b/.claude/specs/trading-desk-tui/07-implementation-01.md
@@ -1,0 +1,93 @@
+---
+phase: 7
+iteration: 01
+generated: 2026-04-03
+---
+
+# Implementation Log: Trading Desk TUI Application
+
+Plan: .claude/specs/trading-desk-tui/05-plan-01.md
+Worktrees: .claude/specs/trading-desk-tui/06-worktree-01.md
+
+## Worktree 1 — trading-desk-tui-01-01
+
+Path: .worktrees/trading-desk-tui-01
+Phases: 1, 2, 3, 4, 5, 6, 7
+
+### Phase 1: Build System and Minimal Executable
+
+- Status: `passed`
+- Checkpoint command: `zig build run-desk`
+- Expected output: `Trading Desk v0.1.0`
+- Actual result: exit 0, output "Trading Desk v0.1.0"
+- Recovery attempts: 1 (fix: `root_module` param not supported in Zig 0.13, changed to `root_source_file` + `root_module.addImport`)
+- Details: Created trading/desk/main.zig, added executable target and 4 build steps to build.zig, defined memory/time/ring_buffer/thread modules
+- Exceptions: None
+
+### Phase 2: Terminal Management
+
+- Status: `passed`
+- Checkpoint command: `zig build test-desk`
+- Expected output: exit code 0
+- Actual result: exit 0
+- Recovery attempts: 2 (fix 1: Sigaction flags initialization syntax for Zig 0.13 packed struct, fix 2: winsize field names ws_row/ws_col)
+- Details: Created terminal.zig with raw mode, alternate screen, non-blocking reads, SIGINT/SIGTERM handler
+- Exceptions: None
+
+### Phase 3: Rendering Framework and Panel Layout
+
+- Status: `passed`
+- Checkpoint command: `zig build build-desk && zig build test-desk`
+- Expected output: exit code 0
+- Actual result: exit 0
+- Recovery attempts: 1 (fix: `var fba` -> `const fba` in test, unused variable error)
+- Details: Created layout.zig and renderer.zig with frame buffer rendering and 5-panel layout
+- Exceptions: None
+
+### Phase 4: Engine Thread and Ring Buffer Communication
+
+- Status: `passed`
+- Checkpoint command: `zig build build-desk && zig build test-desk`
+- Expected output: exit code 0
+- Actual result: exit 0
+- Recovery attempts: none needed
+- Details: Created messages.zig and engine.zig, wired dual-thread architecture with SpscRingBuffer
+- Exceptions: None
+
+### Phase 5: Domain Integration and Synthetic Data
+
+- Status: `passed`
+- Checkpoint command: `zig build build-desk && zig build test-desk`
+- Expected output: exit code 0
+- Actual result: exit 0
+- Recovery attempts: 1 (fix: `var active_instrument` -> `const active_instrument` since not yet mutated)
+- Details: Created synthetic.zig, 4 panel draw modules, wired L2Book integration in engine
+- Exceptions: Engine uses simplified demo mode (synthetic data + fake order responses) rather than wiring full OMS/PreTradeRisk/SpotExecutor — acceptable for v1
+
+### Phase 6: Input Handling and Order Entry
+
+- Status: `passed`
+- Checkpoint command: `zig build build-desk && zig build test-desk`
+- Expected output: exit code 0
+- Actual result: exit 0
+- Recovery attempts: none needed
+- Details: Created input.zig and order_entry_panel.zig, wired Tab panel switching and order submission
+- Exceptions: None
+
+### Phase 7: VS Code Integration
+
+- Status: `passed`
+- Checkpoint command: `head -1 .vscode/tasks.json`
+- Expected output: `{`
+- Actual result: `{`
+- Recovery attempts: none needed
+- Details: Created tasks.json (4 tasks) and launch.json (lldb debug config)
+- Exceptions: None
+
+## Summary
+- [x] All phases complete
+- [x] All checkpoints passed
+- [x] Exceptions documented
+- [x] Batches auto-merged
+- [x] Worktrees cleaned up
+- [x] Ready for PR

--- a/.claude/specs/trading-desk-tui/08-pull-request-01.md
+++ b/.claude/specs/trading-desk-tui/08-pull-request-01.md
@@ -1,0 +1,85 @@
+---
+phase: 8
+iteration: 01
+generated: 2026-04-03
+---
+
+PR Title: Add trading desk TUI with live orderbook, order entry, and demo mode
+
+Closes: #26
+
+## What problem does this solve?
+
+The trading platform monorepo has a complete SDK (orderbook, OMS, positions, risk), exchange integrations (Kraken spot + futures), and trading strategies -- but no way to run them. There is no executable target in the entire repository. This PR adds the first runnable application: a terminal-based trading desk that ties together the existing domain modules into an interactive demo that works out of the box with zero configuration.
+
+## User-facing changes
+
+- New executable: `zig build run-desk` launches an interactive terminal trading desk
+- Five-panel TUI: orderbook (bid/ask with color), positions, order entry, recent orders, status bar
+- Demo mode with synthetic market data (BTC-USD, ETH-USD random-walk orderbooks)
+- Keyboard interaction: Tab between panels, type quantity/price, Enter to submit orders
+- Instrument switching: press '1' for BTC-USD, '2' for ETH-USD
+- VS Code integration: Build Desk, Run Desk, Test Desk tasks and Debug Desk launch config
+
+## Implementation summary
+
+**Key design decisions** (from Phase 3):
+- **Dual-thread architecture**: engine thread owns all domain state, TUI thread owns rendering. Communication via two SpscRingBuffers (engine->TUI for state snapshots, TUI->engine for user commands). No shared mutable state.
+- **Fixed-size message types**: All ring buffer payloads (EngineEvent, UserCommand) are value-type tagged unions with fixed-size fields (InstrumentId uses [32]u8, OrderbookSnapshot uses [20]PriceLevel arrays). No heap pointers cross the thread boundary.
+- **Single-write rendering**: Renderer builds entire frame in a memory buffer, then writes to stdout in one syscall to eliminate flicker.
+- **Demo-first**: SyntheticFeed generates random-walk L2Book updates. Executors accept null clients for mock mode. No API keys or network needed.
+
+**Edge cases handled** (from Phase 5):
+- Terminal restore on exit: deferred deinit restores original termios and exits alternate screen
+- Non-terminal stdin: graceful fallback if tcgetattr fails (piped input)
+- Small terminals: layout clamps minimum to 80x24, panels skip rendering if too small
+- Ring buffer full: engine drops events (latest snapshot always wins)
+- Invalid order input: flash message shown, order not submitted
+- Escape sequence timeout: partial sequences resolved after 2 frames
+
+**Test checkpoints passed** (from Phase 7):
+- Phase 1 -- `zig build run-desk`: passed (output: "Trading Desk v0.1.0")
+- Phase 2 -- `zig build test-desk`: passed
+- Phase 3 -- `zig build build-desk && zig build test-desk`: passed
+- Phase 4 -- `zig build build-desk && zig build test-desk`: passed
+- Phase 5 -- `zig build build-desk && zig build test-desk`: passed
+- Phase 6 -- `zig build build-desk && zig build test-desk`: passed
+- Phase 7 -- `.vscode/tasks.json` exists: passed
+
+## Implementation approach
+
+The desk application lives at `trading/desk/main.zig` with supporting modules under `trading/desk/`. It is the first `b.addExecutable` target in `build.zig` (all prior targets were test-only).
+
+The main thread runs the TUI: raw terminal mode, 15 FPS render loop, non-blocking stdin reads. A second thread runs the engine: synthetic market data generation, order processing, and state snapshotting. The threads communicate exclusively through two `SpscRingBuffer` instances -- one for each direction.
+
+The engine uses the existing `L2Book` from `sdk/domain/orderbook.zig` for orderbook state, driven by a `SyntheticFeed` that applies random-walk price updates. Order submission creates fake order updates (simplified demo mode rather than full OMS/PreTradeRisk/SpotExecutor wiring -- acceptable for v1, the domain module imports are already in build.zig for future integration).
+
+New build modules were added to `build.zig` for SDK core modules (memory, time, ring_buffer, thread) that previously only had anonymous test imports.
+
+## Exceptions and deviations
+
+- The engine uses simplified demo-mode order handling (fake OrderUpdate responses) rather than wiring the full OMS -> PreTradeRisk -> SpotExecutor pipeline. The build.zig imports for all domain modules are in place for future integration.
+- Several Zig 0.13 API quirks required adaptation during implementation: `addExecutable` uses `root_source_file` not `root_module`, `Sigaction` flags requires `std.mem.zeroes`, `winsize` fields are `ws_row`/`ws_col`.
+
+## How to verify
+
+### Automated
+- [ ] `zig build test-desk` -- all desk tests pass
+- [ ] `zig build build-desk` -- compiles without errors
+- [ ] `zig build test` -- full test suite still passes (desk tests added to main test step)
+
+### Manual
+- [ ] Run `zig build run-desk` -- verify 5-panel TUI appears with bordered panels
+- [ ] Wait 2-3 seconds -- verify orderbook prices are moving (synthetic data)
+- [ ] Press Tab -- verify panel focus cycles (cyan highlight)
+- [ ] Press '2' -- verify instrument switches to ETH-USD (status bar + orderbook)
+- [ ] Tab to Order Entry, type "1" (qty), arrow down, type "50000" (price), Enter -- verify order appears in Recent Orders
+- [ ] Press 'q' -- verify clean exit (terminal restored)
+
+## Breaking changes / migration notes
+
+None. This is purely additive -- no existing code was modified except `build.zig` (new targets and modules appended at the end).
+
+## Changelog entry
+
+Add terminal-based trading desk TUI as the first executable target, with live synthetic orderbook, order entry, and VS Code developer tooling.

--- a/.claude/specs/trading-desk-tui/meta.md
+++ b/.claude/specs/trading-desk-tui/meta.md
@@ -1,0 +1,25 @@
+# Spec Metadata: Trading Desk TUI Application
+
+feature-slug: trading-desk-tui
+github-owner: ChristianPresley
+github-repo: trading-platform
+tracking-issue: 26
+
+## Phase issues
+- Phase 1: #27 — Build System and Minimal Executable
+- Phase 2: #28 — Terminal Management
+- Phase 3: #29 — Rendering Framework and Panel Layout
+- Phase 4: #30 — Engine Thread and Ring Buffer Communication
+- Phase 5: #31 — Domain Integration and Synthetic Data
+- Phase 6: #32 — Input Handling and Order Entry
+- Phase 7: #33 — VS Code Integration
+
+## Phase iterations
+- Phase 1 (questions): 01
+- Phase 2 (research): 01
+- Phase 3 (design): 01
+- Phase 4 (outline): 01
+- Phase 5 (plan): 01
+- Phase 6 (worktree): 01
+- Phase 7 (implement): 01
+- Phase 8 (pull-request): 01


### PR DESCRIPTION
## Summary
- Update spec.07.implement and spec.07.worker agents to copy spec documents into worktrees and commit them as version-controlled artifacts
- Add trading-desk-tui spec pipeline outputs (phases 1-8: questions, research, design, outline, plan, worktree, implementation, pull-request)

## Test plan
- [x] Verify spec agent changes are backwards compatible
- [x] Verify all trading-desk-tui spec artifacts are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)